### PR TITLE
Basic twoword classifier

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,1 +1,4 @@
 from scripts.composition_functions import transweigh, transweigh_weight, tw_transform, concat
+from scripts.basic_twoword_classifier import BasicTwoWordClassfier
+
+

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,4 +1,4 @@
 from scripts.composition_functions import transweigh, transweigh_weight, tw_transform, concat
-from scripts.basic_twoword_classifier import BasicTwoWordClassfier
+from scripts.basic_twoword_classifier import BasicTwoWordClassifier
 
 

--- a/scripts/basic_twoword_classifier.py
+++ b/scripts/basic_twoword_classifier.py
@@ -3,7 +3,7 @@ import torch.nn.functional as F
 import scripts.composition_functions as comp_functions
 
 
-class BasicTwoWordClassfier(nn.Module):
+class BasicTwoWordClassifier(nn.Module):
     """
     this class includes a basic two-word classifier with one hidden layer and one output layer.
     :param input_dim: the dimension of the input vector where only embedding size (2 times the size of the embedding of
@@ -13,9 +13,17 @@ class BasicTwoWordClassfier(nn.Module):
     """
 
     def __init__(self, input_dim, hidden_dim, label_nr):
-        super(BasicTwoWordClassfier, self).__init__()
-        self.hidden_layer = nn.Linear(input_dim, hidden_dim)
-        self.output_layer = nn.Linear(hidden_dim, label_nr)
+        super(BasicTwoWordClassifier, self).__init__()
+        self._hidden_layer = nn.Linear(input_dim, hidden_dim)
+        self._output_layer = nn.Linear(hidden_dim, label_nr)
+
+    @property
+    def hidden_layer(self):
+        return self._hidden_layer
+
+    @property
+    def output_layer(self):
+        return self._output_layer
 
     def forward(self, word1, word2):
         """
@@ -26,5 +34,5 @@ class BasicTwoWordClassfier(nn.Module):
         :return: the transformed vectors after output layer
         """
         word_composed = comp_functions.concat(word1, word2, axis=1)
-        x = F.relu(self.hidden_layer(word_composed))
-        return F.relu(self.output_layer(x))
+
+        return self.output_layer(word_composed)

--- a/scripts/basic_twoword_classifier.py
+++ b/scripts/basic_twoword_classifier.py
@@ -1,0 +1,35 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import scripts.composition_functions as comp_functions
+
+
+class BasicTwoWordClassfier(nn.Module):
+    """
+    this class includes a basic two-word classifier with one hidden layer and one output layer.
+    :param input_dim: the dimension of the input vector where only embedding size (2 times the size of the embedding of
+    a single word vector) is needed, batch size is implicit
+    :param hidden_dim : the dimension of the hidden layer, batch size is implicit
+    :param label_nr : the dimension of the output layer, i.e. the number of labels
+    """
+
+    def __init__(self, input_dim, hidden_dim, label_nr):
+        super(BasicTwoWordClassfier, self).__init__()
+        self.hidden_layer = nn.Linear(input_dim, hidden_dim)
+        self.output_layer = nn.Linear(hidden_dim, label_nr)
+
+    def forward(self, word1, word2):
+        """
+        this function takes two words, concatenates them and applies a non-linear matrix transformation. Then
+        it returns the concatenated and transformed vectors.
+        :param word1: the first word of size batch_size x embedding size
+        :param word2: the first word of size batch_size x embedding size
+        """
+        word_composed = comp_functions.concat(word1, word2)
+        x = F.relu(self.hidden_layer(word_composed))
+        return F.relu(self.output_layer(x))
+
+
+
+
+

--- a/scripts/basic_twoword_classifier.py
+++ b/scripts/basic_twoword_classifier.py
@@ -19,8 +19,8 @@ class BasicTwoWordClassfier(nn.Module):
 
     def forward(self, word1, word2):
         """
-        this function takes two words, concatenates them and applies a non-linear matrix transformation. Then
-        it returns the concatenated and transformed vectors.
+        this function takes two words, concatenates them and applies a non-linear matrix transformation (hidden layer)
+        Its output is then fed to an output layer. Then it returns the concatenated and transformed vectors.
         :param word1: the first word of size batch_size x embedding size
         :param word2: the first word of size batch_size x embedding size
         :return: the transformed vectors after output layer

--- a/scripts/basic_twoword_classifier.py
+++ b/scripts/basic_twoword_classifier.py
@@ -1,4 +1,3 @@
-import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import scripts.composition_functions as comp_functions
@@ -24,10 +23,12 @@ class BasicTwoWordClassfier(nn.Module):
         it returns the concatenated and transformed vectors.
         :param word1: the first word of size batch_size x embedding size
         :param word2: the first word of size batch_size x embedding size
+        :return: the transformed vectors after output layer
         """
-        word_composed = comp_functions.concat(word1, word2)
+        word_composed = comp_functions.concat(word1, word2, axis=1)
         x = F.relu(self.hidden_layer(word_composed))
         return F.relu(self.output_layer(x))
+
 
 
 

--- a/scripts/basic_twoword_classifier.py
+++ b/scripts/basic_twoword_classifier.py
@@ -28,9 +28,3 @@ class BasicTwoWordClassfier(nn.Module):
         word_composed = comp_functions.concat(word1, word2, axis=1)
         x = F.relu(self.hidden_layer(word_composed))
         return F.relu(self.output_layer(x))
-
-
-
-
-
-

--- a/scripts/basic_twoword_classifier.py
+++ b/scripts/basic_twoword_classifier.py
@@ -17,14 +17,6 @@ class BasicTwoWordClassifier(nn.Module):
         self._hidden_layer = nn.Linear(input_dim, hidden_dim)
         self._output_layer = nn.Linear(hidden_dim, label_nr)
 
-    @property
-    def hidden_layer(self):
-        return self._hidden_layer
-
-    @property
-    def output_layer(self):
-        return self._output_layer
-
     def forward(self, word1, word2):
         """
         this function takes two words, concatenates them and applies a non-linear matrix transformation (hidden layer)
@@ -34,5 +26,13 @@ class BasicTwoWordClassifier(nn.Module):
         :return: the transformed vectors after output layer
         """
         word_composed = comp_functions.concat(word1, word2, axis=1)
+        x = F.relu(self.hidden_layer(word_composed))
+        return self.output_layer(x)
 
-        return self.output_layer(word_composed)
+    @property
+    def hidden_layer(self):
+        return self._hidden_layer
+
+    @property
+    def output_layer(self):
+        return self._output_layer

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,2 @@
 from tests.test_composition_functions import CompositionFunctionsTest
+from tests.test_basic_twoword_classifier import BasicTwoWordClassifierTest

--- a/tests/test_basic_twoword_classifier.py
+++ b/tests/test_basic_twoword_classifier.py
@@ -1,0 +1,29 @@
+import numpy as np
+import torch
+from scripts import BasicTwoWordClassfier
+import unittest
+
+
+class BasicTwoWordClassifierTest(unittest.TestCase):
+    """
+    this class tests the BasicTwoWordClassifier
+    This test suite can be ran with:
+        python -m unittest -q tests.BasicTwoWordClassifierTest
+    """
+
+    def setUp(self):
+        self.word1 = torch.from_numpy(np.array([[1, 0, 0]], dtype= 'float32'))
+        self.word2 = torch.from_numpy(np.array([[0, 1, 0]], dtype= 'float32'))
+        self.inputdim = 6
+        self.hiddendim = 6
+        self.labels = 2
+
+    def test_forward(self):
+        """
+        tests the classifier implemented in BasicTwoWordClassifier and the overridden method "forward"
+        prints the classifier to check whether the right number of layers exist and the right dimensions are included
+        """
+        classifier = BasicTwoWordClassfier(input_dim=self.inputdim, hidden_dim=self.hiddendim, label_nr=self.labels)
+        classifier.forward(self.word1, self.word2)
+        print(classifier)
+

--- a/tests/test_basic_twoword_classifier.py
+++ b/tests/test_basic_twoword_classifier.py
@@ -12,8 +12,8 @@ class BasicTwoWordClassifierTest(unittest.TestCase):
     """
 
     def setUp(self):
-        self.word1 = torch.from_numpy(np.array([[1, 0, 0]], dtype= 'float32'))
-        self.word2 = torch.from_numpy(np.array([[0, 1, 0]], dtype= 'float32'))
+        self.word1 = torch.from_numpy(np.array([[1, 0, 0]], dtype='float32'))
+        self.word2 = torch.from_numpy(np.array([[0, 1, 0]], dtype='float32'))
         self.inputdim = 6
         self.hiddendim = 6
         self.labels = 2
@@ -26,4 +26,3 @@ class BasicTwoWordClassifierTest(unittest.TestCase):
         classifier = BasicTwoWordClassfier(input_dim=self.inputdim, hidden_dim=self.hiddendim, label_nr=self.labels)
         classifier.forward(self.word1, self.word2)
         print(classifier)
-

--- a/tests/test_basic_twoword_classifier.py
+++ b/tests/test_basic_twoword_classifier.py
@@ -1,6 +1,6 @@
 import numpy as np
 import torch
-from scripts import BasicTwoWordClassfier
+from scripts import BasicTwoWordClassifier
 import unittest
 
 
@@ -14,15 +14,16 @@ class BasicTwoWordClassifierTest(unittest.TestCase):
     def setUp(self):
         self.word1 = torch.from_numpy(np.array([[1, 0, 0]], dtype='float32'))
         self.word2 = torch.from_numpy(np.array([[0, 1, 0]], dtype='float32'))
-        self.inputdim = 6
-        self.hiddendim = 6
+        self.input_dim = 6
+        self.hidden_dim = 6
         self.labels = 2
 
     def test_forward(self):
         """
         tests the classifier implemented in BasicTwoWordClassifier and the overridden method "forward"
-        prints the classifier to check whether the right number of layers exist and the right dimensions are included
+        checks whether the output layer is of the right size
         """
-        classifier = BasicTwoWordClassfier(input_dim=self.inputdim, hidden_dim=self.hiddendim, label_nr=self.labels)
-        classifier.forward(self.word1, self.word2)
-        print(classifier)
+        self.expected_size = torch.tensor(np.array([[0,1]])).shape
+        classifier = BasicTwoWordClassifier(input_dim=self.input_dim, hidden_dim=self.hidden_dim, label_nr=self.labels)
+        res = classifier.forward(self.word1, self.word2)
+        np.testing.assert_allclose(res.shape, self.expected_size)

--- a/tests/test_basic_twoword_classifier.py
+++ b/tests/test_basic_twoword_classifier.py
@@ -23,7 +23,7 @@ class BasicTwoWordClassifierTest(unittest.TestCase):
         tests the classifier implemented in BasicTwoWordClassifier and the overridden method "forward"
         checks whether the output layer is of the right size
         """
-        self.expected_size = torch.tensor(np.array([[0,1]])).shape
+        expected_size = torch.tensor(np.array([[0,1]])).shape
         classifier = BasicTwoWordClassifier(input_dim=self.input_dim, hidden_dim=self.hidden_dim, label_nr=self.labels)
         res = classifier.forward(self.word1, self.word2)
-        np.testing.assert_allclose(res.shape, self.expected_size)
+        np.testing.assert_allclose(res.shape, expected_size)


### PR DESCRIPTION
This branch includes a basic classifier that takes two words as input.

- basic_twoword_classifier.py: includes the class BasicTwoWordClassifier. It inherits the base class Module and overides the method "forward". The simple **concat** method is used to concatenate the two word vectors

- test_basic_twoword_classifier.py: sets up a test environment to test the class above. However, it does not really contain a proper test. It only prints out the network to check whether the dimensions and layers are correct.