### PR TITLE
Cross entropy loss

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,4 +1,4 @@
 from scripts.composition_functions import transweigh, transweigh_weight, tw_transform, concat
 from scripts.basic_twoword_classifier import BasicTwoWordClassifier
-
+from scripts.loss_functions import multi_class_cross_entropy, binary_class_cross_entropy
 

--- a/scripts/loss_functions.py
+++ b/scripts/loss_functions.py
@@ -1,0 +1,34 @@
+import torch.nn.functional as F
+
+def multi_class_cross_entropy(output, target):
+    """
+    This criterion combines log_softmax and nll_loss in a single function.
+    :param output: the input to the loss function is the output as raw, unnormalized scores for each class,
+                    is of size (minibatch, C)
+    :param target: 1D tensor of size minibatch with range [0,C−1] for each value,
+    :return: loss: mean loss of all instances in batch
+    """
+    assert output.shape[0] == target.shape[0], "target shape is the number of batches in output"
+    assert target.dtype != 'float32', "target type has to be \"int\""
+    loss = F.cross_entropy(output, target)
+    return loss
+
+
+# to be done
+def binary_class_cross_entropy(output, target):
+    """
+    :param output: the input to the loss function is the output as raw, unnormalized scores for each class
+    :param target: tensor of the same shape as input
+    :return: loss: mean loss of all instances in batch
+    """
+    assert output.shape[0] == target.shape, "target shape is the number of batches in output" # maybe change
+    loss = F.binary_cross_entropy(F.sigmoid(output), target)
+    return loss
+
+
+
+
+
+
+
+

--- a/scripts/loss_functions.py
+++ b/scripts/loss_functions.py
@@ -1,34 +1,28 @@
 import torch.nn.functional as F
+import torch
+
 
 def multi_class_cross_entropy(output, target):
     """
-    This criterion combines log_softmax and nll_loss in a single function.
+    combines log_softmax and nll_loss in a single function, is used for multiclass classification
     :param output: the input to the loss function is the output as raw, unnormalized scores for each class,
                     is of size (minibatch, C)
     :param target: 1D tensor of size minibatch with range [0,C−1] for each value,
     :return: loss: mean loss of all instances in batch
     """
     assert output.shape[0] == target.shape[0], "target shape is the number of batches in output"
-    assert target.dtype != 'float32', "target type has to be \"int\""
+    assert target.dtype != 'float32', "target type has to be \"int\""  # maybe remove or use regex
     loss = F.cross_entropy(output, target)
     return loss
 
 
-# to be done
 def binary_class_cross_entropy(output, target):
     """
+    applies a sigmoid function plus cross-entropy loss, is used for binary classification
     :param output: the input to the loss function is the output as raw, unnormalized scores for each class
     :param target: tensor of the same shape as input
     :return: loss: mean loss of all instances in batch
     """
-    assert output.shape[0] == target.shape, "target shape is the number of batches in output" # maybe change
-    loss = F.binary_cross_entropy(F.sigmoid(output), target)
+    assert output.shape == target.shape, "target shape is same as output shape"
+    loss = F.binary_cross_entropy(torch.sigmoid(output), target)
     return loss
-
-
-
-
-
-
-
-

--- a/scripts/loss_functions.py
+++ b/scripts/loss_functions.py
@@ -6,12 +6,12 @@ def multi_class_cross_entropy(output, target):
     """
     combines log_softmax and nll_loss in a single function, is used for multiclass classification
     :param output: the input to the loss function is the output as raw, unnormalized scores for each class,
-                    is of size (minibatch, C)
-    :param target: 1D tensor of size minibatch with range [0,C−1] for each value,
+                    is of size (minibatch, C) and of type float
+    :param target: 1D tensor of size minibatch with range [0,C−1] for each value and is of type int
     :return: loss: mean loss of all instances in batch
     """
     assert output.shape[0] == target.shape[0], "target shape is the number of batches in output"
-    assert target.dtype != 'float32', "target type has to be \"int\""  # maybe remove or use regex
+
     loss = F.cross_entropy(output, target)
     return loss
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,3 @@
 from tests.test_composition_functions import CompositionFunctionsTest
 from tests.test_basic_twoword_classifier import BasicTwoWordClassifierTest
+from tests.test_loss_functions import LossFunctionsTest

--- a/tests/test_loss_functions.py
+++ b/tests/test_loss_functions.py
@@ -3,6 +3,7 @@ import torch
 from scripts import multi_class_cross_entropy, binary_class_cross_entropy
 import unittest
 
+
 class LossFunctionsTest(unittest.TestCase):
     """
     this class tests the BasicTwoWordClassifier
@@ -11,15 +12,16 @@ class LossFunctionsTest(unittest.TestCase):
     """
 
     def setUp(self):
-        self.output_tensor = torch.from_numpy(np.array([[5.0, 5.0, 1.0], [0.0, 1.0, 2.0], [1.0,2.0,3.0]],dtype='float32'))
-        self.target_labels = torch.from_numpy(np.array([0,1,2], dtype='long'))
-
-        self.manual_loss = self.calculate_manually(self.output_tensor, self.target_labels)
+        self.output_tensor = torch.from_numpy(
+            np.array([[5.0, 5.0, 1.0], [0.0, 1.0, 2.0], [1.0, 2.0, 3.0]], dtype='float32'))
+        self.target_labels = torch.from_numpy(np.array([0, 1, 2], dtype='long'))
+        self.output_tensor_binary = torch.from_numpy(np.array([0.0, -1.4, -.8, .2, .4, .8, 1.2, 2.2, 2.9, 4.6]))
+        self.target_labels_binary = torch.from_numpy(np.array([1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
 
     @staticmethod
     def calculate_manually(logits, target):
         """
-        Helper method to calculate mean loss manually with the help of numpy
+        Helper method to calculate mean loss manually with the help of numpy (for multiclass loss)
         help from: https://d2l.ai/chapter_linear-networks/softmax-regression-scratch.html and http://cs231n.github.io/neural-networks-case-study/#grad
         """
         logits = logits.numpy()
@@ -27,18 +29,47 @@ class LossFunctionsTest(unittest.TestCase):
         num_examples = logits.shape[0]
 
         exps = [np.exp(i) for i in logits]
-        probs = np.array(exps / np.sum(exps, axis=1, keepdims=True)) # softmax
+        probs = np.array(exps / np.sum(exps, axis=1, keepdims=True))  # softmax
 
-        correct_logprobs = - np.log(probs[range(num_examples), target]) # negative log likelihood
+        correct_logprobs = - np.log(probs[range(num_examples), target])  # negative log likelihood
 
-        return np.sum(correct_logprobs)/num_examples
+        return np.sum(correct_logprobs) / num_examples
 
+    @staticmethod
+    def sigmoid(x):
+        """
+        helper method to calculate sigmoid function
+        """
+        return 1 / (1 + np.exp(-x))
 
+    @staticmethod
+    def cross_entropy(y_hat, y):
+        """
+        helper method to calculate cross entropy
+        """
+        if y == 1:
+            return -np.log(y_hat)
+        else:
+            return -np.log(1 - y_hat)
 
     def test_multiclass_cross_entropy(self):
         """
-        tests whether loss from function corresponds to loss manually calculated
+        multiclass classification: tests whether loss from implemented function corresponds to loss manually calculated
         """
+        expected_loss = self.calculate_manually(self.output_tensor, self.target_labels)
+        loss = multi_class_cross_entropy(output=self.output_tensor, target=self.target_labels)
+        np.testing.assert_allclose(loss, expected_loss)
 
-        loss = multi_class_cross_entropy(self.output_tensor, self.target_labels)
-        np.testing.assert_allclose(loss, self.manual_loss)
+    def test_binary_cross_entropy(self):
+        """
+         binary classification: tests whether loss from implemented function corresponds to loss manually calculated
+         """
+        loss = binary_class_cross_entropy(output=self.output_tensor_binary, target=self.target_labels_binary)
+
+        loss_calc = []
+        for x, y in zip(self.output_tensor_binary, self.target_labels_binary): # apply cross entropy and sigmoid to each element in vector
+            loss_calc.append(self.__cross_entropy(self.__sigmoid(x), y).numpy())
+
+        expected_loss = np.mean(loss_calc)
+
+        np.testing.assert_allclose(loss, expected_loss)

--- a/tests/test_loss_functions.py
+++ b/tests/test_loss_functions.py
@@ -13,10 +13,11 @@ class LossFunctionsTest(unittest.TestCase):
 
     def setUp(self):
         self.output_tensor = torch.from_numpy(
-            np.array([[5.0, 5.0, 1.0], [0.0, 1.0, 2.0], [1.0, 2.0, 3.0]], dtype='float32'))
-        self.target_labels = torch.from_numpy(np.array([0, 1, 2], dtype='long'))
+            np.array([[5.0, 5.0, 1.0], [0.0, 1.0, 2.0], [1.0, 2.0, 3.0]]))
+        self.target_labels = torch.from_numpy(np.array([0, 1, 2]))
         self.output_tensor_binary = torch.from_numpy(np.array([0.0, -1.4, -.8, .2, .4, .8, 1.2, 2.2, 2.9, 4.6]))
         self.target_labels_binary = torch.from_numpy(np.array([1.0, 1.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+
 
     @staticmethod
     def calculate_manually(logits, target):
@@ -30,6 +31,7 @@ class LossFunctionsTest(unittest.TestCase):
 
         exps = [np.exp(i) for i in logits]
         probs = np.array(exps / np.sum(exps, axis=1, keepdims=True))  # softmax
+
 
         correct_logprobs = - np.log(probs[range(num_examples), target])  # negative log likelihood
 
@@ -68,8 +70,10 @@ class LossFunctionsTest(unittest.TestCase):
 
         loss_calc = []
         for x, y in zip(self.output_tensor_binary, self.target_labels_binary): # apply cross entropy and sigmoid to each element in vector
-            loss_calc.append(self.__cross_entropy(self.__sigmoid(x), y).numpy())
+            loss_calc.append(self.cross_entropy(self.sigmoid(x), y).numpy())
 
         expected_loss = np.mean(loss_calc)
 
         np.testing.assert_allclose(loss, expected_loss)
+
+

--- a/tests/test_loss_functions.py
+++ b/tests/test_loss_functions.py
@@ -1,0 +1,44 @@
+import numpy as np
+import torch
+from scripts import multi_class_cross_entropy, binary_class_cross_entropy
+import unittest
+
+class LossFunctionsTest(unittest.TestCase):
+    """
+    this class tests the BasicTwoWordClassifier
+    This test suite can be ran with:
+        python -m unittest -q tests.BasicTwoWordClassifierTest
+    """
+
+    def setUp(self):
+        self.output_tensor = torch.from_numpy(np.array([[5.0, 5.0, 1.0], [0.0, 1.0, 2.0], [1.0,2.0,3.0]],dtype='float32'))
+        self.target_labels = torch.from_numpy(np.array([0,1,2], dtype='long'))
+
+        self.manual_loss = self.calculate_manually(self.output_tensor, self.target_labels)
+
+    @staticmethod
+    def calculate_manually(logits, target):
+        """
+        Helper method to calculate mean loss manually with the help of numpy
+        help from: https://d2l.ai/chapter_linear-networks/softmax-regression-scratch.html and http://cs231n.github.io/neural-networks-case-study/#grad
+        """
+        logits = logits.numpy()
+        target = target.numpy()
+        num_examples = logits.shape[0]
+
+        exps = [np.exp(i) for i in logits]
+        probs = np.array(exps / np.sum(exps, axis=1, keepdims=True)) # softmax
+
+        correct_logprobs = - np.log(probs[range(num_examples), target]) # negative log likelihood
+
+        return np.sum(correct_logprobs)/num_examples
+
+
+
+    def test_multiclass_cross_entropy(self):
+        """
+        tests whether loss from function corresponds to loss manually calculated
+        """
+
+        loss = multi_class_cross_entropy(self.output_tensor, self.target_labels)
+        np.testing.assert_allclose(loss, self.manual_loss)


### PR DESCRIPTION
This branch includes two methods to calculate loss from binary classification task and multiclass classification task. It further contains a test file with two tests.

- `multi_class_cross_entropy` calculates the negative loglikelihood and softmax in one go
- `binary_class_cross_entropy` applies a sigmoid function over the estimated levels and then applies cross-entropy over the value between 0 and 1.

other comments:
- for the multiclass loss: the target labels have to be of type _int_. At the moment I inserted an assert statement to make sure that this is the case. However, we might want to take it out or define it as a regex since `float32` does not account for all cases. Any suggestions?
- the tests were nice for me to actually understand what's going on. However, they're not really helpful since we can trust the library to implement the loss_functions the right way. Any suggestions for other tests?

