### PR TITLE
fix bert extractor

### DIFF
--- a/scripts/data_loader.py
+++ b/scripts/data_loader.py
@@ -7,9 +7,9 @@ from scripts import BertExtractor, StaticEmbeddingExtractor
 
 class SimplePhraseDataset(ABC, Dataset):
     def __init__(self, data_path, separator="\t", phrase="phrase", label="label"):
-        self._data = pandas.read_csv(data_path, delimiter=separator)
-        self._phrases = self.data[phrase]
-        self._labels = self.data[label]
+        self._data = pandas.read_csv(data_path, delimiter=separator, index_col=False)
+        self._phrases = list(self.data[phrase])
+        self._labels = list(self.data[label])
         self._label_encoder = LabelEncoder()
         self._labels, self._label2index = self.encode_labels()
 
@@ -79,7 +79,7 @@ class SimplePhraseContextualizedDataset(SimplePhraseDataset):
     """
 
     def __init__(self, data_path, bert_model,
-                 max_len, lower_case, separator="\t", phrase="phrase", label="label", context="context"):
+                 max_len, lower_case, batch_size, separator="\t", phrase="phrase", label="label", context="context"):
         """
 
         :param data_path: [String] The path to the csv datafile that needs to be transformed into a dataset.
@@ -91,9 +91,10 @@ class SimplePhraseContextualizedDataset(SimplePhraseDataset):
         :param label: [String] the label of the column the class label is stored in
         :param context: [String] the label of the column the context sentence is stored in
         """
-        self._feature_extractor = BertExtractor(bert_model=bert_model, max_len=max_len, lower_case=lower_case)
+        self._feature_extractor = BertExtractor(bert_model=bert_model, max_len=max_len, lower_case=lower_case,
+                                                batch_size=batch_size)
         super(SimplePhraseContextualizedDataset, self).__init__(data_path)
-        self._sentences = self.data[context]
+        self._sentences = list(self.data[context])
         self._samples = self.populate_samples()
 
     def lookup_embedding(self, words):

--- a/scripts/feature_extractor_contextualized.py
+++ b/scripts/feature_extractor_contextualized.py
@@ -116,9 +116,9 @@ class BertExtractor:
                  all_layers: all 12 layers for each token within each sentence.
         """
         with torch.no_grad():
-            last_hidden_states, _, all_layers = self.model(input_ids=torch.tensor(batch_input_ids),
-                                                           attention_mask=torch.tensor(batch_attention_mask),
-                                                           token_type_ids=torch.tensor(batch_token_type_ids))
+            last_hidden_states, _, all_layers = self.model(input_ids=torch.tensor(batch_input_ids).to(self.device),
+                                                           attention_mask=torch.tensor(batch_attention_mask).to(self.device),
+                                                           token_type_ids=torch.tensor(batch_token_type_ids).to(self.device))
         return last_hidden_states, all_layers
 
     @staticmethod

--- a/scripts/feature_extractor_contextualized.py
+++ b/scripts/feature_extractor_contextualized.py
@@ -1,10 +1,12 @@
+import numpy as np
 import torch
 from transformers import BertTokenizer, BertModel
+import progressbar
 
 
 class BertExtractor:
 
-    def __init__(self, bert_model, max_len, lower_case):
+    def __init__(self, bert_model, max_len, lower_case, batch_size):
         """
         This class contains methods to extract contextualized word embeddings with a given Bert model.
         :param bert_model: which of the pretrained Bert model should be loaded.
@@ -12,10 +14,14 @@ class BertExtractor:
         batches and is more efficient
         :param lower_case: whether to lower case or not
         """
+        self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self._model = BertModel.from_pretrained(bert_model, output_hidden_states=True)
+        # move model to GPU if available
+        self.model.to(self.device)
         self._model.eval()
         self._tokenizer = BertTokenizer.from_pretrained(bert_model, do_lower_case=lower_case)
         self._max_len = max_len
+        self._batch_size = batch_size
 
     def convert_sentence_to_indices(self, sentence):
         """
@@ -47,11 +53,9 @@ class BertExtractor:
         for i in range(len(sentence_indices)):
             if sentence_indices[i] == word_indices[0] and sentence_indices[i:i + len(word_indices)] == word_indices:
                 startindex = i
-
                 break
+        return np.arange(startindex, startindex+len(word_indices))
 
-        all_word_indices = [startindex + len(word_indices)-1]
-        return all_word_indices
 
     @staticmethod
     def get_single_word_embedding(token_embeddings, target_word_indices):
@@ -68,6 +72,21 @@ class BertExtractor:
             target_word_tokens = token_embeddings[
                                  target_word_indices[0]:target_word_indices[len(target_word_indices) - 1]]
             return target_word_tokens.sum(0) / target_word_tokens.shape[0]
+
+    def get_sentence_batches(self, sentences):
+        """
+        This method splits a list of sentences into batches for efficient processing.
+        :param sentences: [String] A list of sentences
+        :return: A list of lists, each list except the last element are of length batchsize.
+        """
+        sentence_batches = []
+
+        for i in range(0, len(sentences), self.batch_size):
+            if i + self.batch_size - 1 > len(sentences):
+                sentence_batches.append(sentences[i:])
+            else:
+                sentence_batches.append(sentences[i:i + self.batch_size])
+        return sentence_batches
 
     def convert_sentence_batch_to_indices(self, sentences):
         """
@@ -130,18 +149,26 @@ class BertExtractor:
         bert
         """
         assert len(sentences) == len(target_words), "for every sentence exactly one target word needs to be given."
-        batch_input_ids, batch_token_type_ids, batch_attention_mask = self.convert_sentence_batch_to_indices(sentences)
-        # shape last_hidden_states : batch_size x max_len x embedding_dim
-        last_hidden_states, all_layers = self.get_bert_vectors(batch_input_ids=batch_input_ids,
-                                                               batch_attention_mask=batch_attention_mask,
-                                                               batch_token_type_ids=batch_token_type_ids)
+        # split sentence and target words into batches
+
+        sentence_batches = self.get_sentence_batches(sentences)
+        target_word_batches = self.get_sentence_batches(target_words)
         contextualized_embeddings = []
-        for i in range(len(sentences)):
-            target_word_indices = self.word_indices_in_sentence(sentences[i], target_words[i])
-            token_embeddings = last_hidden_states[i]
-            contextualized_emb = self.get_single_word_embedding(token_embeddings=token_embeddings,
-                                                                target_word_indices=target_word_indices)
-            contextualized_embeddings.append(contextualized_emb)
+        # extract bert vectors for each batch
+        for i in progressbar.progressbar(range(0, len(sentence_batches))):
+            current_sentences = sentence_batches[i]
+            current_target_words = target_word_batches[i]
+            batch_input_ids, batch_token_type_ids, batch_attention_mask = self.convert_sentence_batch_to_indices(current_sentences)
+            # shape last_hidden_states : batch_size x max_len x embedding_dim
+            last_hidden_states, all_layers = self.get_bert_vectors(batch_input_ids=batch_input_ids,
+                                                                   batch_attention_mask=batch_attention_mask,
+                                                                   batch_token_type_ids=batch_token_type_ids)
+            for i in range(len(current_sentences)):
+                target_word_indices = self.word_indices_in_sentence(current_sentences[i], current_target_words[i])
+                token_embeddings = last_hidden_states[i]
+                contextualized_emb = self.get_single_word_embedding(token_embeddings=token_embeddings,
+                                                                    target_word_indices=target_word_indices)
+                contextualized_embeddings.append(contextualized_emb.to("cpu"))
         return torch.stack(contextualized_embeddings)
 
     @property
@@ -155,3 +182,11 @@ class BertExtractor:
     @property
     def max_len(self):
         return self._max_len
+
+    @property
+    def batch_size(self):
+        return self._batch_size
+
+    @property
+    def device(self):
+        return self._device

--- a/scripts/training_utils.py
+++ b/scripts/training_utils.py
@@ -37,16 +37,23 @@ def get_datasets(config):
     dataset_valid = None
     if config["feature_extractor"]["contextualized_embeddings"] is True:
         bert_parameter = config["feature_extractor"]["contextualized"]["bert"]
+        bert_model = bert_parameter["model"]
+        max_len = bert_parameter["max_sent_len"]
+        lower_case = bert_parameter["lower_case"]
+        batch_size = bert_parameter["batch_size"]
         if config["feature_extractor"]["context"] is False:
             dataset_train = SimplePhraseContextualizedDataset(data_path=config["train_data_path"],
-                                                              bert_model=bert_parameter[0], max_len=bert_parameter[1],
-                                                              lower_case=bert_parameter[2])
+                                                              bert_model=bert_model,
+                                                              lower_case=lower_case, max_len=max_len,
+                                                              batch_size=batch_size)
             dataset_valid = SimplePhraseContextualizedDataset(data_path=config["validation_data_path"],
-                                                              bert_model=bert_parameter[0], max_len=bert_parameter[1],
-                                                              lower_case=bert_parameter[2])
+                                                              bert_model=bert_model,
+                                                              lower_case=lower_case, max_len=max_len,
+                                                              batch_size=batch_size)
             dataset_test = SimplePhraseContextualizedDataset(data_path=config["test_data_path"],
-                                                             bert_model=bert_parameter[0], max_len=bert_parameter[1],
-                                                             lower_case=bert_parameter[2])
+                                                             bert_model=bert_model,
+                                                             lower_case=lower_case, max_len=max_len,
+                                                             batch_size=batch_size)
     else:
         dataset_train = SimplePhraseStaticDataset(data_path=config["train_data_path"],
                                                   embedding_path=config["feature_extractor"]["static"][

--- a/tests/config.json
+++ b/tests/config.json
@@ -21,7 +21,12 @@
     "contextualized_embeddings": true,
     "static_embeddings": false,
     "contextualized": {
-      "bert": ["bert-base-german-cased", 200, false]
+      "bert": {
+        "model" : "bert-base-german-cased",
+        "max_sent_len" : 200,
+        "lower_case" : false,
+        "batch_size" : 100
+      }
     },
 
     "static": {

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -18,7 +18,7 @@ class DataLoaderTest(unittest.TestCase):
             "embeddings/german-skipgram-mincount-30-ctx-10-dims-300.fifu"))
 
         self._contextualized_dataset = SimplePhraseContextualizedDataset(self._data_path, 'bert-base-german-cased', 20,
-                                                                         False)
+                                                                         False, 20)
         self._static_dataset = SimplePhraseStaticDataset(self._data_path, self._embedding_path)
 
     def test_exception(self):


### PR DESCRIPTION
This PR contains some modifications for extracting contextualized Word Embeddings:
- there was a bug in extracting target word indices in a sentence, the method returned only the last index of a target word within a sentence and not a list with all indices from start till end. The method is fixed now and the test has been modified to test for a target word that is splitted into several word pieces
- the Bert extractor now expects an additional argument: batch_size. This has to be passed on as well when constructing a corresponding dataset. this is necessary when extracting embeddings for a larger dataset as bert can be run on a GPU which speeds up the process then. this splits the list of sentences into batches and runs the Bert Model for a small set of sentences batch per batch
- the config files has been changed to have that arguments and all bert arguments have names now