### PR TITLE
Change output dataloader

### DIFF
--- a/scripts/basic_twoword_classifier.py
+++ b/scripts/basic_twoword_classifier.py
@@ -17,7 +17,8 @@ class BasicTwoWordClassifier(nn.Module):
         self._hidden_layer = nn.Linear(input_dim, hidden_dim)
         self._output_layer = nn.Linear(hidden_dim, label_nr)
         self._dropout_rate = dropout_rate
-    def forward(self, word1, word2, training=True):
+    #def forward(self, word1, word2, training=True):
+    def forward(self, batch, training=True):
         """
         this function takes two words, concatenates them and applies a non-linear matrix transformation (hidden layer)
         Its output is then fed to an output layer. Then it returns the concatenated and transformed vectors.
@@ -25,7 +26,9 @@ class BasicTwoWordClassifier(nn.Module):
         :param word2: the first word of size batch_size x embedding size
         :return: the transformed vectors after output layer
         """
-        word_composed = comp_functions.concat(word1, word2, axis=1)
+
+        word_composed = comp_functions.concat(batch["w1"], batch["w2"], axis=1)
+        #word_composed = comp_functions.concat(word1, word2, axis=1)
         x = F.relu(self.hidden_layer(word_composed))
         x = F.dropout(x, training=training, p=self.dropout_rate)
         return self.output_layer(x)

--- a/scripts/data_loader.py
+++ b/scripts/data_loader.py
@@ -210,6 +210,7 @@ class PhraseAndContextDatasetStatic(SimplePhraseDataset):
         return [{"w1": word1_embeddings[i],
                                 "w2" : word2_embeddings[i],
                                 "seq":sequences[i],
+                                "seq_lengths": sequence_lengths[i],
                                 "l": self.labels[i]} for i in range(len(self.labels))]
         #return [SimpleNamespace(word1_embs = word1_embeddings[i],
          #                   word2_embs= word2_embeddings[i],
@@ -292,8 +293,15 @@ class PhraseAndContextDatasetBert(SimplePhraseDataset):
 
         sequence_lengths = np.array([len(words) for words in self.sentences])
 
-        return [[word1_embeddings[i], word2_embeddings[i], sequences[i], sequence_lengths[i], self.labels[i]] for i in
-                range(len(self.labels))]
+        return [{"w1": word1_embeddings[i],
+                                "w2" : word2_embeddings[i],
+                                "seq":sequences[i],
+                                "seq_lengths": sequence_lengths[i],
+                                "l": self.labels[i]} for i in range(len(self.labels))]
+
+
+        #return [[word1_embeddings[i], word2_embeddings[i], sequences[i], sequence_lengths[i], self.labels[i]] for i in
+         #       range(len(self.labels))]
 
     @property
     def feature_extractor(self):

--- a/scripts/data_loader.py
+++ b/scripts/data_loader.py
@@ -7,6 +7,7 @@ from torch import nn
 import somajo
 import numpy as np
 from scripts import BertExtractor, StaticEmbeddingExtractor
+from types import SimpleNamespace
 
 
 class SimplePhraseDataset(ABC, Dataset):
@@ -107,7 +108,7 @@ class SimplePhraseContextualizedDataset(SimplePhraseDataset):
     def populate_samples(self):
         word1_embeddings = self.lookup_embedding(self.word1)
         word2_embeddings = self.lookup_embedding(self.word2)
-        return [[word1_embeddings[i], word2_embeddings[i], self.labels[i]] for i in range(len(self.labels))]
+        return [{"w1": word1_embeddings[i], "w2": word2_embeddings[i], "l": self.labels[i]} for i in range(len(self.labels))]
 
     @property
     def feature_extractor(self):
@@ -145,7 +146,13 @@ class SimplePhraseStaticDataset(SimplePhraseDataset):
     def populate_samples(self):
         word1_embeddings = self.lookup_embedding(self.word1)
         word2_embeddings = self.lookup_embedding(self.word2)
-        return [[word1_embeddings[i], word2_embeddings[i], self.labels[i]] for i in range(len(self.labels))]
+
+        return [{"w1": word1_embeddings[i], "w2": word2_embeddings[i], "l": self.labels[i]} for i in range(len(self.labels))]
+
+        #return [SimpleNamespace(word1_embs=word1_embeddings[i],
+         #                       word2_embs=word2_embeddings[i],
+          #                      labs=self.labels[i]) for i in range(len(self.labels))]
+        #return [[word1_embeddings[i], word2_embeddings[i], self.labels[i]] for i in range(len(self.labels))]
 
     @property
     def feature_extractor(self):
@@ -199,9 +206,18 @@ class PhraseAndContextDatasetStatic(SimplePhraseDataset):
         sequences = nn.utils.rnn.pad_sequence(batch_first=True, sequences=sequences, padding_value=0.0)
 
         sequence_lengths = np.array([len(words) for words in self.sentences])
+        list_of_namespaces = []
+        return [{"w1": word1_embeddings[i],
+                                "w2" : word2_embeddings[i],
+                                "seq":sequences[i],
+                                "l": self.labels[i]} for i in range(len(self.labels))]
+        #return [SimpleNamespace(word1_embs = word1_embeddings[i],
+         #                   word2_embs= word2_embeddings[i],
+          #                  seqs = sequences[i],
+           #                 labs = self.labels[i]) for i in range(len(self.labels))]
 
-        return [[word1_embeddings[i], word2_embeddings[i], sequences[i], sequence_lengths[i], self.labels[i]] for i in
-                range(len(self.labels))]
+        #return [[word1_embeddings[i], word2_embeddings[i], sequences[i], sequence_lengths[i], self.labels[i]] for i in
+                #range(len(self.labels))]
 
     @property
     def feature_extractor(self):

--- a/scripts/phrase_context_classifier.py
+++ b/scripts/phrase_context_classifier.py
@@ -29,12 +29,12 @@ class PhraseContextClassifier(nn.Module):
         self._hidden_layer = nn.Linear(2 * embedding_dim + hidden_size * 2, forward_hidden_dim)
         self._output_layer = nn.Linear(forward_hidden_dim, label_nr)
 
-    def forward(self, word1, word2, context, context_lengths, training, device):
+    def forward(self, batch, training, device):
         # context size = batchsize x max len x embedding dim
         # convert the padded context into a packed sequence such that the padded vectors are not shown to the LSTM
         # context_packed = sum of all seq lenghts, embedding_dim
         # batch_sizes = column-wise (how many real elements do I have?)
-        context_packed = nn.utils.rnn.pack_padded_sequence(context, context_lengths, batch_first=True,
+        context_packed = nn.utils.rnn.pack_padded_sequence(batch["seq"], batch["seq_lengths"], batch_first=True,
                                                            enforce_sorted=False)
         self.lstm.to(device)
         # forward propagate LSTM, initial states are set to 0 per default
@@ -49,7 +49,7 @@ class PhraseContextClassifier(nn.Module):
         out = out[:, -1, :]
 
         # concat the word vectors into phrase
-        word_composed = comp_functions.concat(word1, word2, axis=1)
+        word_composed = comp_functions.concat(batch["w1"], batch["w2"], axis=1)
 
         # concate phrase with encoded sequence and send through forward
         context_phrase = torch.cat((word_composed, out), 1)

--- a/scripts/transfer_comp_classifier.py
+++ b/scripts/transfer_comp_classifier.py
@@ -30,7 +30,7 @@ class TransferCompClassifier(nn.Module):
         self._dropout_rate = dropout_rate
         self._normalize_embeddings = normalize_embeddings
 
-    def forward(self, word1, word2, training):
+    def forward(self, batch, training):
         """
         First composes the input vectors into one representation. This is then feed trough a hidden layer with a Relu and
         finally trough an output layer that returns weights for each class.
@@ -40,7 +40,7 @@ class TransferCompClassifier(nn.Module):
         :return: the raw weights for each class
         """
 
-        self._composed_phrase = self.compose(word1, word2, training)
+        self._composed_phrase = self.compose(batch["w1"], batch["w2"], training)
         hidden = F.relu(self.hidden(self.composed_phrase))
         hidden = F.dropout(hidden, training=training, p=self.dropout_rate)
         class_weights = self.output(hidden)

--- a/scripts/transweigh_twoword_classifier.py
+++ b/scripts/transweigh_twoword_classifier.py
@@ -34,7 +34,7 @@ class TransweighTwoWordClassifier(nn.Module):
         self._dropout_rate = dropout_rate
         self._normalize_embeddings = normalize_embeddings
 
-    def forward(self, word1, word2, training):
+    def forward(self, batch, training):
         """
         First composes the input vectors into one representation. This is then feed trough a hidden layer with a Relu and
         finally trough an output layer that returns weights for each class.
@@ -43,7 +43,7 @@ class TransweighTwoWordClassifier(nn.Module):
         :param training: training: True if the model should be trained, False if the model is in inference
         :return: the raw weights for each class
         """
-        self._composed_phrase = self.compose(word1, word2, training)
+        self._composed_phrase = self.compose(batch["w1"], batch["w2"], training)
         hidden = F.relu(self.hidden(self.composed_phrase))
         hidden = F.dropout(hidden, training=training, p=self.dropout_rate)
         class_weights = self.output(hidden)

--- a/tests/test_basic_twoword_classifier.py
+++ b/tests/test_basic_twoword_classifier.py
@@ -2,7 +2,9 @@ import numpy as np
 import torch
 from scripts import BasicTwoWordClassifier
 import unittest
-
+from scripts import SimplePhraseStaticDataset
+import pathlib
+from torch.utils.data import DataLoader
 
 class BasicTwoWordClassifierTest(unittest.TestCase):
     """
@@ -12,19 +14,26 @@ class BasicTwoWordClassifierTest(unittest.TestCase):
     """
 
     def setUp(self):
-        self.word1 = torch.from_numpy(np.array([[1, 0, 0]], dtype='float32'))
-        self.word2 = torch.from_numpy(np.array([[0, 1, 0]], dtype='float32'))
-        self.input_dim = 6
+        #self.word1 = torch.from_numpy(np.array([[1, 0, 0]], dtype='float32'))
+        #self.word2 = torch.from_numpy(np.array([[0, 1, 0]], dtype='float32'))
+        self._data_path = pathlib.Path(__file__).parent.absolute().joinpath("data_multiclassification/test.txt")
+        self._embedding_path = str(pathlib.Path(__file__).parent.absolute().joinpath(
+            "embeddings/german-skipgram-mincount-30-ctx-10-dims-300.fifu"))
+        self._static_dataset = SimplePhraseStaticDataset(self._data_path, self._embedding_path)
+        self._data = DataLoader(self._static_dataset, batch_size=2)
+        self._batch = next(iter(self._data))
+
+        self.input_dim = 600
         self.hidden_dim = 6
-        self.labels = 2
+        self.labels = 6
 
     def test_forward(self):
         """
         tests the classifier implemented in BasicTwoWordClassifier and the overridden method "forward"
         checks whether the output layer is of the right size
         """
-        expected_size = torch.tensor(np.array([[0, 1]])).shape
+        expected_size = torch.tensor(np.zeros((2,6))).shape
         classifier = BasicTwoWordClassifier(input_dim=self.input_dim, hidden_dim=self.hidden_dim, label_nr=self.labels,
                                             dropout_rate=0.0)
-        res = classifier.forward(self.word1, self.word2)
+        res = classifier.forward(self._batch)
         np.testing.assert_allclose(res.shape, expected_size)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -30,15 +30,17 @@ class DataLoaderTest(unittest.TestCase):
         labels have the shape (batchsize)
         """
         dataloader = DataLoader(self._contextualized_dataset, batch_size=5, shuffle=True, num_workers=2)
-        w1, w2, l = next(iter(dataloader))
-        np.testing.assert_equal(np.array(w1.shape), [5, 768])
-        np.testing.assert_equal(np.array(w2.shape), [5, 768])
-        np.testing.assert_equal(np.array(l.shape), [5])
+
+        data = next(iter(dataloader))
+
+        np.testing.assert_equal(np.array(data["w1"].shape), [5, 768])
+        np.testing.assert_equal(np.array(data["w2"].shape), [5, 768])
+        np.testing.assert_equal(np.array(data["l"].shape), [5])
         dataloader = DataLoader(self._static_dataset, batch_size=5, shuffle=True, num_workers=2)
-        w1, w2, l = next(iter(dataloader))
-        np.testing.assert_equal(np.array(w1.shape), [5, 300])
-        np.testing.assert_equal(np.array(w2.shape), [5, 300])
-        np.testing.assert_equal(np.array(l.shape), [5])
+        data = next(iter(dataloader))
+        np.testing.assert_equal(np.array(data["w1"].shape), [5, 300])
+        np.testing.assert_equal(np.array(data["w2"].shape), [5, 300])
+        np.testing.assert_equal(np.array(data["l"].shape), [5])
 
     def test_labels(self):
         """Test whether the label dictionary contains 3 different labels for the multiclass classification dataset"""

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -21,6 +21,7 @@ class DataLoaderTest(unittest.TestCase):
                                                                          False, 20)
         self._static_dataset = SimplePhraseStaticDataset(self._data_path, self._embedding_path)
 
+
     def test_exception(self):
         """ Trying to initialize the abstract Dataset should throw a Type Exception """
         self.assertRaises(TypeError, lambda: SimplePhraseDataset(self._data_path))

--- a/tests/test_phrase_context_classifier.py
+++ b/tests/test_phrase_context_classifier.py
@@ -35,10 +35,11 @@ class PhraseContextClassifierTest(unittest.TestCase):
                                  batch_size=64,
                                  shuffle=True,
                                  num_workers=0)
-        for word1, word2, context, context_len, labels in data_loader:
+
+        for batch in data_loader:
             # context is a list of list of word embeddings
-            out = self.model(word1, word2, context, context_len, True).squeeze()
-            loss = multi_class_cross_entropy(out, labels)
+            out = self.model(batch, True, "cpu").squeeze()
+            loss = multi_class_cross_entropy(out, batch["l"])
             loss.backward()
             self.optimizer.step()
             self.optimizer.zero_grad()
@@ -46,4 +47,3 @@ class PhraseContextClassifierTest(unittest.TestCase):
         loss = loss.data.numpy()
         np.testing.assert_equal(math.isnan(loss), False)
         np.testing.assert_equal(loss >= 0, True)
-

--- a/tests/test_transfer_comp_classifier.py
+++ b/tests/test_transfer_comp_classifier.py
@@ -4,7 +4,8 @@ from torch import optim
 import torch
 import pathlib
 import numpy as np
-
+from scripts import SimplePhraseContextualizedDataset
+from torch.utils.data import DataLoader
 
 class TransferCompClassifierTest(unittest.TestCase):
     """
@@ -25,10 +26,11 @@ class TransferCompClassifierTest(unittest.TestCase):
         self.variables = ["_transformation_tensor", "_transformation_bias", "_combining_tensor", "_combining_bias",
                           "_hidden.weight", "_hidden.bias", "_output.weight", "_output.bias"]
 
-        self.optimizer_binary = optim.Adam(self.model.parameters(), lr=0.1)
-        self.word1 = torch.from_numpy(np.array([[0.9, 0.5, 1.5, 1.0], [0.1, 0.5, 0.1, 1.0]], dtype=np.float32))
-        self.word2 = torch.from_numpy(np.array([[0.5, 0.3, 0.7, 0.1], [0.1, 0.5, 0.6, 0.1]], dtype=np.float32))
-        self.label = torch.from_numpy(np.array([[1.0], [0.0]], dtype=np.float32))
+        self._data_path = pathlib.Path(__file__).parent.absolute().joinpath("data_multiclassification/test.txt")
+        self._contextualized_dataset = SimplePhraseContextualizedDataset(self._data_path, 'bert-base-german-cased', 20,
+                                                                         False, 20)
+        self._data = DataLoader(self._contextualized_dataset , batch_size=2)
+        self._batch = next(iter(self._data))
 
     @staticmethod
     def access_named_parameter(model, parameter_name):
@@ -49,7 +51,6 @@ class TransferCompClassifierTest(unittest.TestCase):
         model_transformation_bias = self._pretrained_model["_transformation_bias"]
         model_combination_tensor = self._pretrained_model["_combining_tensor"]
         model_combination_bias = self._pretrained_model["_combining_bias"]
-
         np.testing.assert_equal((torch.sum(self.access_named_parameter(self.model,
                                                                        "_transformation_tensor") -
                                            model_transformation_tensor).item()) == 0.0,


### PR DESCRIPTION
In this PR, the return variables are changed in the DataLoader so that one training script can be used for all kinds of classifiers.
The following parts of the code had to be changed:
- data loader: return list changed to return dictionary
- all classifiers (the forward method)
- all tests connected to the parts metnioned above
- train.py

train_rnn.py has not been removed. Also, the phrase_context classifier does not work yet because of the additional parameter  (_device_) in the forward method.
 