### PR TITLE
pretrain composition model

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -14,4 +14,5 @@ from scripts.data_loader import SimplePhraseStaticDataset, SimplePhraseContextua
 
 from scripts.data_loader import SimplePhraseContextualizedDataset, SimplePhraseStaticDataset
 from scripts.phrase_context_classifier import PhraseContextClassifier
+from scripts.transweigh_pretrain import TransweighPretrain
 

--- a/scripts/loss_functions.py
+++ b/scripts/loss_functions.py
@@ -26,3 +26,22 @@ def binary_class_cross_entropy(output, target):
     assert output.shape == target.shape, "target shape is same as output shape"
     loss = F.binary_cross_entropy(torch.sigmoid(output), target)
     return loss
+
+
+def get_loss_cosine_distance(original_phrase, composed_phrase, dim=1, normalize=False):
+    """
+    Computes the cosine distance between two given phrases. The distance can be used to pretrain a composition model.
+    :param original_phrase: the gold standard representations
+    :param composed_phrase: the representations retrieved from the composition model
+    :param dim: along which dimension to compute the distance and to normalize, default=1 for two batches
+    :param normalize: Whether the input embeddings should be normalized, the function expects the input to already be
+    normalized
+    :return: The averaged cosine distance for one batch
+    """
+    assert original_phrase.shape == composed_phrase.shape, "shapes of original and composed phrase have to be the same"
+    if normalize:
+        original_phrase = F.normalize(original_phrase, p=2, dim=dim)
+        composed_phrase = F.normalize(original_phrase, p=2, dim=dim)
+    cosine_distances = 1 - F.cosine_similarity(original_phrase, composed_phrase, dim)
+    total = torch.sum(cosine_distances)
+    return total / original_phrase.shape[0]

--- a/scripts/transweigh_pretrain.py
+++ b/scripts/transweigh_pretrain.py
@@ -1,0 +1,86 @@
+import torch
+from torch import nn
+from torch.functional import F
+from scripts import transweigh
+
+
+class TransweighPretrain(nn.Module):
+    """
+    This class contains a model that takes two (batches of) word representations as input and combines them via
+    transformations. The transformed, composed vector can be optimized compared to a gold representation.
+    The composition model can thus be trained on reconstructing a gold representation of a two-word phrase.
+    """
+
+    def __init__(self, input_dim, dropout_rate, transformations, normalize_embeddings):
+        super().__init__()
+        # --- we create the following variable that will be trainable parameters for our classifier:
+
+        # the transformation tensor for transforming the input vectors
+        self._transformation_tensor = nn.Parameter(
+            torch.empty(transformations, 2 * input_dim, input_dim), requires_grad=True)
+        nn.init.xavier_normal_(self.transformation_tensor)
+        self._transformation_bias = nn.Parameter(torch.empty(transformations, input_dim), requires_grad=True)
+        nn.init.uniform_(self.transformation_bias)
+        # - the combining tensor combines the transformed phrase representation into a final, flat vector
+        self._combining_tensor = nn.Parameter(data=torch.empty(transformations, input_dim, input_dim),
+                                              requires_grad=True)
+        nn.init.xavier_normal_(self.combining_tensor)
+        self._combining_bias = nn.Parameter(torch.empty(input_dim), requires_grad=True)
+        nn.init.uniform_(self.combining_bias)
+        self._dropout_rate = dropout_rate
+        self._normalize_embeddings = normalize_embeddings
+
+    def forward(self, batch):
+        """
+        Composes the input vectors into one representation.
+        :param word1: word1: the representation of the first word (torch tensor)
+        :param word2: word2: the representation of the second word (torch tensor)
+        :return: the composed representation, same shape as each input representation
+        """
+        self._composed_phrase = self.compose(batch["w1"], batch["w2"])
+        return self.composed_phrase
+
+    def compose(self, word1, word2):
+        """
+        This functions composes two input representations with the transformation weighting model. If set to True,
+        the composed representation is normalized
+        :param word1: the representation of the first word (torch tensor)
+        :param word2: the representation of the second word (torch tensor)
+        :param training: True if the model should be trained, False if the model is in inference
+        :return: the composed vector representation, eventually normalized to unit norm
+        """
+        composed_phrase = transweigh(word1=word1, word2=word2, transformation_tensor=self.transformation_tensor,
+                                     transformation_bias=self.transformation_bias, combining_bias=self.combining_bias,
+                                     combining_tensor=self.combining_tensor, dropout_rate=self.dropout_rate,
+                                     training=self.training)
+        if self.normalize_embeddings:
+            composed_phrase = F.normalize(composed_phrase, p=2, dim=1)
+        return composed_phrase
+
+    @property
+    def combining_tensor(self):
+        return self._combining_tensor
+
+    @property
+    def combining_bias(self):
+        return self._combining_bias
+
+    @property
+    def transformation_tensor(self):
+        return self._transformation_tensor
+
+    @property
+    def transformation_bias(self):
+        return self._transformation_bias
+
+    @property
+    def dropout_rate(self):
+        return self._dropout_rate
+
+    @property
+    def normalize_embeddings(self):
+        return self._normalize_embeddings
+
+    @property
+    def composed_phrase(self):
+        return self._composed_phrase

--- a/tests/test_pretrain_transweigh.py
+++ b/tests/test_pretrain_transweigh.py
@@ -1,0 +1,85 @@
+import unittest
+import math
+import numpy as np
+import torch
+from torch import optim
+from scripts import loss_functions
+import torch.nn.functional as F
+from scripts import TransweighPretrain
+
+
+class PretrainTransweighTest(unittest.TestCase):
+    """
+    this class tests the training utils script
+    This test suite can be ran with:
+        python -m unittest -q tests.PretrainTransweighTest
+    """
+
+    def setUp(self):
+        modifier_embeddings = F.normalize(torch.rand((50, 100)), dim=1)
+        head_embeddings = F.normalize(torch.rand((50, 100)), dim=1)
+        gold_composed = F.normalize(torch.rand((50, 100)), dim=1)
+        self.input = {"w1": modifier_embeddings, "w2": head_embeddings, "l": gold_composed}
+
+        self.model = TransweighPretrain(input_dim=100, dropout_rate=0.0, normalize_embeddings=True, transformations=10)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=0.1)
+
+    def test_cosine_distance(self):
+        """Test whether the cosine distance is 0 for two equal batches of embeddings"""
+        embedding_1 = torch.from_numpy(np.array([[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]))
+        embedding_2 = torch.from_numpy(np.array([[0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]))
+        distance = loss_functions.get_loss_cosine_distance(original_phrase=embedding_1, composed_phrase=embedding_2,
+                                                           dim=1,
+                                                           normalize=True)
+        np.testing.assert_equal(distance.item(), 0.0)
+
+    @staticmethod
+    def acess_named_parameter(model, parameter_name):
+        for name, param in model.named_parameters():
+            if param.requires_grad:
+                if name == parameter_name:
+                    return param.clone()
+
+    def test_model_loss(self):
+        """
+        Test whether the composition model can be ran and whether the loss can be computed. The loss should be
+        a number larger than zero and not NaN
+        """
+        self.optimizer.zero_grad()
+        composed = self.model(self.input)
+        loss = loss_functions.get_loss_cosine_distance(original_phrase=self.input["l"], composed_phrase=composed,
+                                                       dim=1, normalize=False).item()
+        np.testing.assert_equal(math.isnan(loss), False)
+        np.testing.assert_equal(loss >= 0, True)
+
+    def test_parameter_get_updated(self):
+        """Test whether initial weight matrices are being updated during training. These parameters should be different
+        after training vs before training."""
+        tw_tensor_before_training = self.acess_named_parameter(self.model, "_transformation_tensor")
+        combining_tensor_before_training = self.acess_named_parameter(self.model, "_combining_tensor")
+
+        for epoch in range(0, 10):
+            self.optimizer.zero_grad()
+            composed = self.model(self.input)
+            loss = loss_functions.get_loss_cosine_distance(original_phrase=self.input["l"], composed_phrase=composed,
+                                                           dim=1, normalize=False)
+            loss.backward()
+            self.optimizer.step()
+            tw_tensor_after_training = self.acess_named_parameter(self.model, "_transformation_tensor")
+            combining_tensor_after_training = self.acess_named_parameter(self.model, "_combining_tensor")
+        difference_combining_tensor = torch.sum(
+            combining_tensor_before_training - combining_tensor_after_training).item()
+        difference_tw_tensor = torch.sum(tw_tensor_before_training - tw_tensor_after_training).item()
+        np.testing.assert_equal(difference_combining_tensor != 0.0, True)
+        np.testing.assert_equal(difference_tw_tensor != 0.0, True)
+
+    def test_output_shape(self):
+        """Test whether the output shape of the composed representation is as expected"""
+        expected_shape = np.array([50, 100])
+        composed_phrase = self.model(self.input)
+        np.testing.assert_almost_equal(composed_phrase.shape, expected_shape)
+
+    def test_embedding_normalization(self):
+        """Test whether the composed phrase has been normalized to unit norm"""
+        composed_phrase = self.model(self.input)
+        np.testing.assert_almost_equal(np.linalg.norm(composed_phrase[0].data), 1)


### PR DESCRIPTION
This PR includes the transweigh composition model that returns a composed phrase. A loss function has been added that computes the cosine distance between two given embeddings. Thus a composition model can be pretrained on a general task, e.g. reconstruct some gold standard vectors. A test has been added as well. The dataset and the pretraining method will be added an a separate PR, otherwise it would be too chaotic.