### PR TITLE
all training parameters taken out

### DIFF
--- a/scripts/basic_twoword_classifier.py
+++ b/scripts/basic_twoword_classifier.py
@@ -18,7 +18,7 @@ class BasicTwoWordClassifier(nn.Module):
         self._output_layer = nn.Linear(hidden_dim, label_nr)
         self._dropout_rate = dropout_rate
 
-    def forward(self, batch, training=True):
+    def forward(self, batch):
         """
         this function takes two words, concatenates them and applies a non-linear matrix transformation (hidden layer)
         Its output is then fed to an output layer. Then it returns the concatenated and transformed vectors.
@@ -29,7 +29,7 @@ class BasicTwoWordClassifier(nn.Module):
         device = batch["device"]
         word_composed = comp_functions.concat(batch["w1"].to(device), batch["w2"].to(device), axis=1)
         x = F.relu(self.hidden_layer(word_composed))
-        x = F.dropout(x, training=training, p=self.dropout_rate)
+        x = F.dropout(x, p=self.dropout_rate)
         return self.output_layer(x)
 
     @property

--- a/scripts/phrase_context_classifier.py
+++ b/scripts/phrase_context_classifier.py
@@ -29,7 +29,7 @@ class PhraseContextClassifier(nn.Module):
         self._hidden_layer = nn.Linear(2 * embedding_dim + hidden_size * 2, forward_hidden_dim)
         self._output_layer = nn.Linear(forward_hidden_dim, label_nr)
 
-    def forward(self, batch, training):
+    def forward(self, batch):
         # context size = batchsize x max len x embedding dim
         # convert the padded context into a packed sequence such that the padded vectors are not shown to the LSTM
         # context_packed = sum of all seq lenghts, embedding_dim
@@ -55,7 +55,7 @@ class PhraseContextClassifier(nn.Module):
         # concate phrase with encoded sequence and send through forward
         context_phrase = torch.cat((word_composed, out), 1)
         x = F.relu(self._hidden_layer(context_phrase))
-        x = F.dropout(x, training=training, p=self.dropout_rate)
+        x = F.dropout(x, p=self.dropout_rate)
         return self._output_layer(x)
 
     @property

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -44,7 +44,7 @@ def train_binary(config, train_loader, valid_loader, model_path, device):
         # for word1, word2, labels in train_loader:
         for batch in train_loader:
             batch["device"] = device
-            out = model(batch, True).squeeze().to("cpu")
+            out = model(batch).squeeze().to("cpu")
             loss = binary_class_cross_entropy(out, batch["l"].float())
             loss.backward()
             optimizer.step()
@@ -54,7 +54,7 @@ def train_binary(config, train_loader, valid_loader, model_path, device):
         model.eval()
         for batch in valid_loader:
             batch["device"] = device
-            out = model(batch, False).squeeze().to("cpu")
+            out = model(batch).squeeze().to("cpu")
             predictions = convert_logits_to_binary_predictions(out)
             loss = binary_class_cross_entropy(out, batch["l"].float())
             valid_losses.append(loss.item())
@@ -114,7 +114,7 @@ def train_multiclass(config, train_loader, valid_loader, model_path, device):
         valid_accuracies = []
         for batch in train_loader:
             batch["device"] = device
-            out = model(batch, True).to("cpu")
+            out = model(batch).to("cpu")
             loss = multi_class_cross_entropy(out, batch["l"])
             loss.backward()
             optimizer.step()
@@ -124,7 +124,7 @@ def train_multiclass(config, train_loader, valid_loader, model_path, device):
         model.eval()
         for batch in valid_loader:
             batch["device"] = device
-            out = model(batch, False).to("cpu")
+            out = model(batch).to("cpu")
             _, predictions = torch.max(out, 1)
             loss = multi_class_cross_entropy(out, batch["l"])
             valid_losses.append(loss.item())
@@ -168,8 +168,9 @@ def predict(test_loader, model, config, device):  # for test set
     accuracy = []
     for batch in test_loader:
         batch["device"] = device
-        out = model(batch, False).to("cpu")
+        out = model(batch).to("cpu")
         if config["model"]["classification"] == "multi":
+
             test_loss.append(multi_class_cross_entropy(out, batch["l"]).item())
             _, prediction = torch.max(out, 1)
             prediction = prediction.tolist()

--- a/scripts/transfer_comp_classifier.py
+++ b/scripts/transfer_comp_classifier.py
@@ -30,7 +30,7 @@ class TransferCompClassifier(nn.Module):
         self._dropout_rate = dropout_rate
         self._normalize_embeddings = normalize_embeddings
 
-    def forward(self, batch, training):
+    def forward(self, batch):
         """
         First composes the input vectors into one representation. This is then feed trough a hidden layer with a Relu and
         finally trough an output layer that returns weights for each class.
@@ -40,9 +40,9 @@ class TransferCompClassifier(nn.Module):
         :return: the raw weights for each class
         """
         device = batch["device"]
-        self._composed_phrase = self.compose(batch["w1"].to(device), batch["w2"].to(device), training)
+        self._composed_phrase = self.compose(batch["w1"].to(device), batch["w2"].to(device), self.training)
         hidden = F.relu(self.hidden(self.composed_phrase))
-        hidden = F.dropout(hidden, training=training, p=self.dropout_rate)
+        hidden = F.dropout(hidden, p=self.dropout_rate)
         class_weights = self.output(hidden)
         return class_weights
 
@@ -51,6 +51,7 @@ class TransferCompClassifier(nn.Module):
                                      transformation_bias=self.transformation_bias, combining_bias=self.combining_bias,
                                      combining_tensor=self.combining_tensor, dropout_rate=self.dropout_rate,
                                      training=training)
+        print(training)
         if self.normalize_embeddings:
             composed_phrase = F.normalize(composed_phrase, p=2, dim=1)
         return composed_phrase

--- a/scripts/transfer_comp_classifier.py
+++ b/scripts/transfer_comp_classifier.py
@@ -51,7 +51,6 @@ class TransferCompClassifier(nn.Module):
                                      transformation_bias=self.transformation_bias, combining_bias=self.combining_bias,
                                      combining_tensor=self.combining_tensor, dropout_rate=self.dropout_rate,
                                      training=training)
-        print(training)
         if self.normalize_embeddings:
             composed_phrase = F.normalize(composed_phrase, p=2, dim=1)
         return composed_phrase

--- a/scripts/transweigh_twoword_classifier.py
+++ b/scripts/transweigh_twoword_classifier.py
@@ -34,7 +34,7 @@ class TransweighTwoWordClassifier(nn.Module):
         self._dropout_rate = dropout_rate
         self._normalize_embeddings = normalize_embeddings
 
-    def forward(self, batch, training):
+    def forward(self, batch):
         """
         First composes the input vectors into one representation. This is then feed trough a hidden layer with a Relu and
         finally trough an output layer that returns weights for each class.
@@ -44,9 +44,9 @@ class TransweighTwoWordClassifier(nn.Module):
         :return: the raw weights for each class
         """
         device = batch["device"]
-        self._composed_phrase = self.compose(batch["w1"].to(device), batch["w2"].to(device), training)
+        self._composed_phrase = self.compose(batch["w1"].to(device), batch["w2"].to(device), self.training)
         hidden = F.relu(self.hidden(self.composed_phrase))
-        hidden = F.dropout(hidden, training=training, p=self.dropout_rate)
+        hidden = F.dropout(hidden, p=self.dropout_rate)
         class_weights = self.output(hidden)
         return class_weights
 

--- a/tests/config.json
+++ b/tests/config.json
@@ -2,15 +2,15 @@
 { "train_data_path": "../tests/data_binary_classification/train.txt",
   "validation_data_path": "../tests/data_binary_classification/val.txt",
   "test_data_path": "../tests/data_binary_classification/test.txt",
-  "logging_path": "logger",
+  "logging_path": "/Users/ehuber/Documents/ambiguous_alpaca/ambigous-alpaca/tests/logger/",
   "save_name" : "test_runs_",
-  "model_path" : "trained_models",
+  "model_path" : "../trained_models",
   "pretrained_model_path": "/Users/ehuber/Documents/ambiguous_alpaca/ambigous-alpaca/trained_models/test_runs__2020-02-18-09_20_20",
   "eval_on_test" : true,
 
   "model": {
     "type": "transweigh_twoword",
-    "classification": "binary",
+    "classification": "multi",
     "dropout": 0.2,
     "input_dim" : 300,
     "hidden_size": 200,


### PR DESCRIPTION
In this PR, all training parameters were taken out of the forward methods. 
The model sets training=False automatically when the model is in eval mode.
This was checked by printing the model's training variable at each point in the training script.
Additionally, I changed the trainig parameter in the classifiers including the transweigh models. In those models, the class variable "self.training" is given to the composition model (as the composition model is always in the same mode (eval or train) as the classifier). I'm not fully sure whether this is necessary but the transweigh method asks for a training parameter and it's probably wrong if we hardcode it. 