### PR TITLE
more dynamic handling of different datasets

### DIFF
--- a/tests/test_configs/config.json
+++ b/tests/test_configs/config.json
@@ -2,14 +2,8 @@
 { "train_data_path": "../tests/data_binary_classification/train.txt",
   "validation_data_path": "../tests/data_binary_classification/val.txt",
   "test_data_path": "../tests/data_binary_classification/test.txt",
-  "logging_path": "/Users/ehuber/Documents/ambiguous_alpaca/ambigous-alpaca/tests/logger/",
-  "save_name" : "test_runs_",
-  "model_path" : "../trained_models",
-  "pretrained_model_path": "/Users/ehuber/Documents/ambiguous_alpaca/ambigous-alpaca/trained_models/test_runs__2020-02-18-09_20_20",
-  "eval_on_test" : true,
-
   "model": {
-    "type": "transweigh_twoword",
+    "type": "basic_twoword",
     "classification": "multi",
     "dropout": 0.2,
     "input_dim" : 300,
@@ -50,15 +44,6 @@
     "type": "basic",
     "batch_size": 64
   },
-  "trainer": {
-    "optimizer": {
-      "type": "adam",
-      "lr": 0.001
-    }
-  },
-  "validation_metric": "accuracy",
-  "num_serialized_models_to_keep": 3,
   "num_epochs": 75,
   "patience": 5,
-  "cuda_device": 0,
   "seed" :  1}

--- a/tests/test_configs/phrase_context_contextualized_config.json
+++ b/tests/test_configs/phrase_context_contextualized_config.json
@@ -1,0 +1,38 @@
+{
+  "train_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/val.txt",
+  "validation_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/val.txt",
+  "test_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/val.txt",
+  "data_loader": {
+    "separator": "\t",
+    "phrase": "phrase",
+    "label": "label",
+    "context": "context",
+    "modifier": "modifier",
+    "head": "head"
+  },
+    "model": {
+    "type": "basic_twoword"
+  },
+  "feature_extractor": {
+    "contextualized_embeddings": true,
+    "static_embeddings": false,
+    "contextualized": {
+      "bert": {
+        "model": "bert-base-german-cased",
+        "max_sent_len": 200,
+        "lower_case": false,
+        "batch_size": 100
+      }
+    },
+    "static": {
+      "type": "skipgram",
+      "pretrained_model": "embeddings/german-skipgram-mincount-30-ctx-10-dims-300.fifu"
+    },
+    "context": true,
+    "sentence_pooling": "mean",
+    "second_sentence": false
+  },
+  "sequence": {
+    "tokenizer": "de_CMC"
+  }
+}

--- a/tests/test_configs/phrase_context_contextualized_config.json
+++ b/tests/test_configs/phrase_context_contextualized_config.json
@@ -1,7 +1,7 @@
 {
-  "train_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/val.txt",
-  "validation_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/val.txt",
-  "test_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/val.txt",
+  "train_data_path": "data_multiclassification/val.txt",
+  "validation_data_path": "data_multiclassification/val.txt",
+  "test_data_path": "data_multiclassification/val.txt",
   "data_loader": {
     "separator": "\t",
     "phrase": "phrase",

--- a/tests/test_configs/phrase_context_static_config.json
+++ b/tests/test_configs/phrase_context_static_config.json
@@ -26,7 +26,7 @@
     },
     "static": {
       "type": "skipgram",
-      "pretrained_model": "embeddings/german-skipgram-mincount-30-ctx-10-dims-300.fifu"
+      "pretrained_model": "embeddings/german-structgram-mincount-30-ctx-10-dims-300.fifu"
     },
     "context": true,
     "sentence_pooling": "mean",

--- a/tests/test_configs/phrase_context_static_config.json
+++ b/tests/test_configs/phrase_context_static_config.json
@@ -1,7 +1,7 @@
 {
-  "train_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/val.txt",
-  "validation_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/val.txt",
-  "test_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/val.txt",
+  "train_data_path": "data_multiclassification/val.txt",
+  "validation_data_path": "data_multiclassification/val.txt",
+  "test_data_path": "data_multiclassification/val.txt",
   "data_loader": {
     "separator": "\t",
     "phrase": "phrase",

--- a/tests/test_configs/phrase_context_static_config.json
+++ b/tests/test_configs/phrase_context_static_config.json
@@ -1,0 +1,38 @@
+{
+  "train_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/val.txt",
+  "validation_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/val.txt",
+  "test_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/val.txt",
+  "data_loader": {
+    "separator": "\t",
+    "phrase": "phrase",
+    "label": "label",
+    "context": "context",
+    "modifier": "modifier",
+    "head": "head"
+  },
+    "model": {
+    "type": "basic_twoword"
+  },
+  "feature_extractor": {
+    "contextualized_embeddings": false,
+    "static_embeddings": true,
+    "contextualized": {
+      "bert": {
+        "model": "bert-base-german-cased",
+        "max_sent_len": 200,
+        "lower_case": false,
+        "batch_size": 100
+      }
+    },
+    "static": {
+      "type": "skipgram",
+      "pretrained_model": "embeddings/german-skipgram-mincount-30-ctx-10-dims-300.fifu"
+    },
+    "context": true,
+    "sentence_pooling": "mean",
+    "second_sentence": false
+  },
+  "sequence": {
+    "tokenizer": "de_CMC"
+  }
+}

--- a/tests/test_configs/simple_phrase_config.json
+++ b/tests/test_configs/simple_phrase_config.json
@@ -26,7 +26,7 @@
     },
     "static": {
       "type": "skipgram",
-      "pretrained_model": "embeddings/german-skipgram-mincount-30-ctx-10-dims-300.fifu"
+      "pretrained_model": "embeddings/german-structgram-mincount-30-ctx-10-dims-300.fifu"
     },
     "context": false,
     "sentence_pooling": "mean",

--- a/tests/test_configs/simple_phrase_config.json
+++ b/tests/test_configs/simple_phrase_config.json
@@ -1,0 +1,35 @@
+{
+  "train_data_path": "data_multiclassification/train.txt",
+  "validation_data_path": "data_multiclassification/val.txt",
+  "test_data_path": "data_multiclassification/test.txt",
+  "data_loader": {
+    "separator": "\t",
+    "phrase": "phrase",
+    "label": "label",
+    "context": "context",
+    "modifier": "modifier",
+    "head": "head"
+  },
+  "model": {
+    "type": "basic_twoword"
+  },
+  "feature_extractor": {
+    "contextualized_embeddings": false,
+    "static_embeddings": true,
+    "contextualized": {
+      "bert": {
+        "model": "bert-base-german-cased",
+        "max_sent_len": 200,
+        "lower_case": false,
+        "batch_size": 100
+      }
+    },
+    "static": {
+      "type": "skipgram",
+      "pretrained_model": "embeddings/german-skipgram-mincount-30-ctx-10-dims-300.fifu"
+    },
+    "context": false,
+    "sentence_pooling": "mean",
+    "second_sentence": false
+  }
+}

--- a/tests/test_configs/simple_phrase_contextualized_config.json
+++ b/tests/test_configs/simple_phrase_contextualized_config.json
@@ -1,7 +1,7 @@
 {
-  "train_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/train.txt",
-  "validation_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/val.txt",
-  "test_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/test.txt",
+  "train_data_path": "../tests/data_multiclassification/train.txt",
+  "validation_data_path": "../ambigous-alpaca/tests/data_multiclassification/val.txt",
+  "test_data_path": "../ambigous-alpaca/tests/data_multiclassification/test.txt",
   "data_loader": {
     "separator": "\t",
     "phrase": "phrase",

--- a/tests/test_configs/simple_phrase_contextualized_config.json
+++ b/tests/test_configs/simple_phrase_contextualized_config.json
@@ -1,0 +1,35 @@
+{
+  "train_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/train.txt",
+  "validation_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/val.txt",
+  "test_data_path": "/Users/nwitte/PycharmProjects/ambigous-alpaca/tests/data_multiclassification/test.txt",
+  "data_loader": {
+    "separator": "\t",
+    "phrase": "phrase",
+    "label": "label",
+    "context": "context",
+    "modifier": "modifier",
+    "head": "head"
+  },
+    "model": {
+    "type": "basic_twoword"
+  },
+  "feature_extractor": {
+    "contextualized_embeddings": true,
+    "static_embeddings": false,
+    "contextualized": {
+      "bert": {
+        "model": "bert-base-german-cased",
+        "max_sent_len": 200,
+        "lower_case": false,
+        "batch_size": 100
+      }
+    },
+    "static": {
+      "type": "skipgram",
+      "pretrained_model": "embeddings/german-skipgram-mincount-30-ctx-10-dims-300.fifu"
+    },
+    "context": false,
+    "sentence_pooling": "mean",
+    "second_sentence": false
+  }
+}

--- a/tests/test_configs/simple_phrase_contextualized_config.json
+++ b/tests/test_configs/simple_phrase_contextualized_config.json
@@ -1,7 +1,7 @@
 {
-  "train_data_path": "../tests/data_multiclassification/train.txt",
-  "validation_data_path": "../ambigous-alpaca/tests/data_multiclassification/val.txt",
-  "test_data_path": "../ambigous-alpaca/tests/data_multiclassification/test.txt",
+  "train_data_path": "data_multiclassification/train.txt",
+  "validation_data_path": "data_multiclassification/val.txt",
+  "test_data_path": "data_multiclassification/test.txt",
   "data_loader": {
     "separator": "\t",
     "phrase": "phrase",
@@ -26,7 +26,7 @@
     },
     "static": {
       "type": "skipgram",
-      "pretrained_model": "embeddings/german-skipgram-mincount-30-ctx-10-dims-300.fifu"
+      "pretrained_model": "embeddings/german-structgram-mincount-30-ctx-10-dims-300.fifu"
     },
     "context": false,
     "sentence_pooling": "mean",

--- a/tests/test_training_utils.py
+++ b/tests/test_training_utils.py
@@ -13,7 +13,7 @@ class TrainingUtilsTest(unittest.TestCase):
     """
 
     def setUp(self):
-        config_path = str(pathlib.Path(__file__).parent.absolute().joinpath("test_config.json"))
+        config_path = str(pathlib.Path(__file__).parent.absolute().joinpath("test_configs/config.json"))
         with open(config_path, 'r') as f:
             self.config = json.load(f)
 
@@ -30,4 +30,3 @@ class TrainingUtilsTest(unittest.TestCase):
         np.testing.assert_equal(classifier.dropout_rate, 0.2)
 
         np.testing.assert_equal(classifier.dropout_rate, 0.2)
-


### PR DESCRIPTION
this PR contains the following

- data_loader and training_utils are updated: the names of the columns (e.g. how the label is called in the dataset, how the columns are separated in the csv etc.) are specified in the config files in a dedicated json section, called "data_loader". Thus, datasets can have columns of different names and they can either be separated by tab or white space. The configuration needs to specify these column names.
- the tests are updated: the tests for data loader and training utils now both make use of the methods in training utils to test whether everything was specified correctly there. 
- constructed a separate config directory in the tests, were we can store configurations that are used in tests
- note: the tests for data loader and training utils are very slow because of Bert (I was constructing only one bert dataset before but now I construct three)
