### PR TITLE
add matrix composition model classifier

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,7 +1,7 @@
 from scripts.composition_functions import transweigh, transweigh_weight, tw_transform, concat
 from scripts.basic_twoword_classifier import BasicTwoWordClassifier
 from scripts.feature_extractor_contextualized import BertExtractor
-from scripts.loss_functions import multi_class_cross_entropy, binary_class_cross_entropy
+from scripts.loss_functions import multi_class_cross_entropy, binary_class_cross_entropy, get_loss_cosine_distance
 
 from scripts.logger_config import create_config
 
@@ -15,4 +15,6 @@ from scripts.data_loader import SimplePhraseStaticDataset, SimplePhraseContextua
 from scripts.data_loader import SimplePhraseContextualizedDataset, SimplePhraseStaticDataset
 from scripts.phrase_context_classifier import PhraseContextClassifier
 from scripts.transweigh_pretrain import TransweighPretrain
-
+from scripts.matrix_pretrain import MatrixPretrain
+from scripts.matrix_twoword_classifier import MatrixTwoWordClassifier
+from scripts.matrix_transfer_classifier import MatrixTransferClassifier

--- a/scripts/matrix_pretrain.py
+++ b/scripts/matrix_pretrain.py
@@ -1,0 +1,70 @@
+import torch.nn as nn
+import torch.nn.functional as F
+import scripts.composition_functions as comp_functions
+
+
+class MatrixPretrain(nn.Module):
+
+    def __init__(self, input_dim, dropout_rate, normalize_embeddings):
+        """
+        This class cotanins the matrix composition model that can be used to train a model with the cosine distance loss
+        The model takes two words and returns their composed representation.
+        :param input_dim: embedding dimension
+        :param dropout_rate: dropout rate for regularization
+        :param normalize_embeddings: whether the composed representation should be normalized to unit length
+        """
+        super(MatrixPretrain, self).__init__()
+        self._matrix_layer = nn.Linear(input_dim * 2, input_dim)
+        self._dropout_rate = dropout_rate
+        self._normalize_embeddings = normalize_embeddings
+
+    def forward(self, batch):
+        """
+        this function takes two words and combines them via the matrix composition model.
+        :param word1: the first word of size batch_size x embedding size
+        :param word2: the first word of size batch_size x embedding size
+        :return: the composed representation
+        """
+        device = batch["device"]
+        self._composed_phrase = self.compose(batch["w1"].to(device), batch["w2"].to(device))
+        return self.composed_phrase
+
+    def compose(self, word1, word2):
+        """
+        this function takes two words, concatenates them and applies a non-linear matrix transformation (
+        hidden layer)
+        Its output is then fed to an output layer. Then it returns the concatenated and transformed vectors.
+        :param word1: the first word of size batch_size x embedding size
+        :param word2: the first word of size batch_size x embedding size
+        :return: the raw label scores
+        """
+        composed_phrase = comp_functions.concat(word1, word2, axis=1)
+        transformed = F.relu(self.matrix_layer(composed_phrase))
+        reg_transformed = F.dropout(transformed, p=self.dropout_rate)
+        if self.normalize_embeddings:
+            reg_transformed = F.normalize(reg_transformed, p=2, dim=1)
+        return reg_transformed
+
+    @property
+    def hidden_layer(self):
+        return self._hidden_layer
+
+    @property
+    def output_layer(self):
+        return self._output_layer
+
+    @property
+    def dropout_rate(self):
+        return self._dropout_rate
+
+    @property
+    def matrix_layer(self):
+        return self._matrix_layer
+
+    @property
+    def normalize_embeddings(self):
+        return self._normalize_embeddings
+
+    @property
+    def composed_phrase(self):
+        return self._composed_phrase

--- a/scripts/matrix_pretrain.py
+++ b/scripts/matrix_pretrain.py
@@ -39,7 +39,7 @@ class MatrixPretrain(nn.Module):
         :return: the raw label scores
         """
         composed_phrase = comp_functions.concat(word1, word2, axis=1)
-        transformed = F.relu(self.matrix_layer(composed_phrase))
+        transformed = self.matrix_layer(composed_phrase)
         reg_transformed = F.dropout(transformed, p=self.dropout_rate)
         if self.normalize_embeddings:
             reg_transformed = F.normalize(reg_transformed, p=2, dim=1)

--- a/scripts/matrix_transfer_classifier.py
+++ b/scripts/matrix_transfer_classifier.py
@@ -1,0 +1,100 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import scripts.composition_functions as comp_functions
+
+
+class MatrixTransferClassifier(nn.Module):
+
+    def __init__(self, input_dim, hidden_dim, label_nr, dropout_rate, normalize_embeddings, pretrained_model,
+                 add_single_words=False):
+        """
+        this class includes a two-word classifier with one hidden layer and one output layer.
+        the classifier first combines the two words with a matrix that will be trained during training and then uses
+        the
+        composed representation and eventually the single word representations as input to the classification layer.
+        The weight and bias of the composition model are loaded from a pretrained model and then trained further.
+        :param input_dim: embedding size
+        :param hidden_dim: dimension of hidden layer of classifier
+        :param label_nr: number of classes to predict
+        :param dropout_rate: dropout rate for regularization
+        :param normalize_embeddings: whether the composed representation should be normalized to unit length
+        :param add_single_words: if True, the classifier will get a concatenation of the single word embeddings with
+        the composed representation, otherwise the composed representation only
+        :param pretrained_model: a pretrained torch model of the type (MatrixTwoWordClassifier)
+        """
+        super(MatrixTransferClassifier, self).__init__()
+        # init matrix model with pretrained weights
+        self._pretrained_w = nn.Parameter(pretrained_model['_matrix_layer.weight'], requires_grad=True)
+        self._pretrained_b = nn.Parameter(pretrained_model['_matrix_layer.bias'], requires_grad=True)
+        self._matrix_layer = nn.Linear(input_dim * 2, input_dim)
+        self._matrix_layer.weight = self._pretrained_w
+        self._matrix_layer.bias = self._pretrained_b
+
+        forward_dim = input_dim
+        self._add_single_words = add_single_words
+        self._normalize_embeddings = normalize_embeddings
+        if self.add_single_words:
+            forward_dim = input_dim * 3
+        self._hidden_layer = nn.Linear(forward_dim, hidden_dim)
+        self._output_layer = nn.Linear(hidden_dim, label_nr)
+        self._dropout_rate = dropout_rate
+
+    def forward(self, batch):
+        """
+        this function takes two words, concatenates them and applies a non-linear matrix transformation (hidden layer)
+        Its output is then fed to an output layer. Then it returns the concatenated and transformed vectors.
+        :param word1: the first word of size batch_size x embedding size
+        :param word2: the first word of size batch_size x embedding size
+        :return: the raw label scores
+        """
+        device = batch["device"]
+        self._composed_phrase = self.compose(batch["w1"].to(device), batch["w2"].to(device))
+        if self.add_single_words:
+            w1_w2 = torch.cat((batch["w1"].to(device), batch["w2"].to(device)), 1)
+            self._composed_phrase = torch.cat((w1_w2, self.composed_phrase), 1)
+        x = F.relu(self.hidden_layer(self.composed_phrase))
+        x = F.dropout(x, p=self.dropout_rate)
+        return self.output_layer(x)
+
+    def compose(self, word1, word2):
+        """
+        Two words are combined via a matrix : relu(word1;word2 x W)+b
+        :param word1: embedding of the first word
+        :param word2: embedding of the second word
+        :return: composed input word embeddings (dimension = embedding dimension)
+        """
+        composed_phrase = comp_functions.concat(word1, word2, axis=1)
+        transformed = F.relu(self.matrix_layer(composed_phrase))
+        reg_transformed = F.dropout(transformed, p=self.dropout_rate)
+        if self.normalize_embeddings:
+            reg_transformed = F.normalize(reg_transformed, p=2, dim=1)
+        return reg_transformed
+
+    @property
+    def hidden_layer(self):
+        return self._hidden_layer
+
+    @property
+    def output_layer(self):
+        return self._output_layer
+
+    @property
+    def dropout_rate(self):
+        return self._dropout_rate
+
+    @property
+    def matrix_layer(self):
+        return self._matrix_layer
+
+    @property
+    def normalize_embeddings(self):
+        return self._normalize_embeddings
+
+    @property
+    def composed_phrase(self):
+        return self._composed_phrase
+
+    @property
+    def add_single_words(self):
+        return self._add_single_words

--- a/scripts/matrix_transfer_classifier.py
+++ b/scripts/matrix_transfer_classifier.py
@@ -65,7 +65,7 @@ class MatrixTransferClassifier(nn.Module):
         :return: composed input word embeddings (dimension = embedding dimension)
         """
         composed_phrase = comp_functions.concat(word1, word2, axis=1)
-        transformed = F.relu(self.matrix_layer(composed_phrase))
+        transformed = self.matrix_layer(composed_phrase)
         reg_transformed = F.dropout(transformed, p=self.dropout_rate)
         if self.normalize_embeddings:
             reg_transformed = F.normalize(reg_transformed, p=2, dim=1)

--- a/scripts/matrix_twoword_classifier.py
+++ b/scripts/matrix_twoword_classifier.py
@@ -1,0 +1,92 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import scripts.composition_functions as comp_functions
+
+
+class MatrixTwoWordClassifier(nn.Module):
+
+    def __init__(self, input_dim, hidden_dim, label_nr, dropout_rate, normalize_embeddings,
+                 add_single_words=False):
+        """
+        this class includes a two-word classifier with one hidden layer and one output layer.
+        the classifier first combines the two words with a matrix that will be trained during training and then uses
+        the
+        composed representation and eventually the single word representations as input to the classification layer
+        :param input_dim: embedding size
+        :param hidden_dim: dimension of hidden layer of classifier
+        :param label_nr: number of classes to predict
+        :param dropout_rate: dropout rate for regularization
+        :param normalize_embeddings: whether the composed representation should be normalized to unit length
+        :param add_single_words: if True, the classifier will get a concatenation of the single word embeddings with
+        the composed representation, otherwise the composed representation only
+        """
+        super(MatrixTwoWordClassifier, self).__init__()
+        self._matrix_layer = nn.Linear(input_dim * 2, input_dim)
+        forward_dim = input_dim
+        self._add_single_words = add_single_words
+        self._normalize_embeddings = normalize_embeddings
+        if self.add_single_words:
+            forward_dim = input_dim * 3
+        self._hidden_layer = nn.Linear(forward_dim, hidden_dim)
+        self._output_layer = nn.Linear(hidden_dim, label_nr)
+        self._dropout_rate = dropout_rate
+
+    def forward(self, batch):
+        """
+        this function takes two words, combines them via the matrix composition function send them through a
+        nonlinear forward layer, eventually after concatenating the single word embeddings.
+        :param word1: the first word of size batch_size x embedding size
+        :param word2: the first word of size batch_size x embedding size
+        :return: the raw label scores
+        """
+        device = batch["device"]
+        self._composed_phrase = self.compose(batch["w1"].to(device), batch["w2"].to(device))
+        if self.add_single_words:
+            w1_w2 = torch.cat((batch["w1"].to(device), batch["w2"].to(device)), 1)
+            self._composed_phrase = torch.cat((w1_w2, self.composed_phrase), 1)
+        x = F.relu(self.hidden_layer(self.composed_phrase))
+        x = F.dropout(x, p=self.dropout_rate)
+        return self.output_layer(x)
+
+    def compose(self, word1, word2):
+        """
+        Two words are combined via a matrix : relu(word1;word2 x W)+b
+        :param word1: embedding of the first word
+        :param word2: embedding of the second word
+        :return: composed input word embeddings (dimension = embedding dimension)
+        """
+        composed_phrase = comp_functions.concat(word1, word2, axis=1)
+        transformed = F.relu(self.matrix_layer(composed_phrase))
+        reg_transformed = F.dropout(transformed, p=self.dropout_rate)
+        if self.normalize_embeddings:
+            reg_transformed = F.normalize(reg_transformed, p=2, dim=1)
+        return reg_transformed
+
+    @property
+    def hidden_layer(self):
+        return self._hidden_layer
+
+    @property
+    def output_layer(self):
+        return self._output_layer
+
+    @property
+    def dropout_rate(self):
+        return self._dropout_rate
+
+    @property
+    def matrix_layer(self):
+        return self._matrix_layer
+
+    @property
+    def normalize_embeddings(self):
+        return self._normalize_embeddings
+
+    @property
+    def composed_phrase(self):
+        return self._composed_phrase
+
+    @property
+    def add_single_words(self):
+        return self._add_single_words

--- a/scripts/matrix_twoword_classifier.py
+++ b/scripts/matrix_twoword_classifier.py
@@ -57,7 +57,7 @@ class MatrixTwoWordClassifier(nn.Module):
         :return: composed input word embeddings (dimension = embedding dimension)
         """
         composed_phrase = comp_functions.concat(word1, word2, axis=1)
-        transformed = F.relu(self.matrix_layer(composed_phrase))
+        transformed = self.matrix_layer(composed_phrase)
         reg_transformed = F.dropout(transformed, p=self.dropout_rate)
         if self.normalize_embeddings:
             reg_transformed = F.normalize(reg_transformed, p=2, dim=1)

--- a/scripts/training_utils.py
+++ b/scripts/training_utils.py
@@ -1,6 +1,6 @@
 import torch
 from scripts import BasicTwoWordClassifier, TransweighTwoWordClassifier, TransferCompClassifier, \
-    PhraseContextClassifier, TransweighPretrain
+    PhraseContextClassifier, TransweighPretrain, MatrixTwoWordClassifier, MatrixPretrain, MatrixTransferClassifier
 
 from scripts.data_loader import SimplePhraseContextualizedDataset, SimplePhraseStaticDataset, \
     PhraseAndContextDatasetStatic, PhraseAndContextDatasetBert, PretrainCompmodelDataset
@@ -28,6 +28,13 @@ def init_classifier(config):
                                                  normalize_embeddings=config["model"]["normalize_embeddings"],
                                                  transformations=config["model"]["transformations"],
                                                  add_single_words=config["model"]["add_single_words"])
+    if config["model"]["type"] == "matrix_twoword":
+        classifier = MatrixTwoWordClassifier(input_dim=config["model"]["input_dim"],
+                                             hidden_dim=config["model"]["hidden_size"],
+                                             dropout_rate=config["model"]["dropout"],
+                                             label_nr=config["model"]["label_size"],
+                                             normalize_embeddings=config["model"]["normalize_embeddings"],
+                                             add_single_words=config["model"]["add_single_words"])
 
     if config["model"]["type"] == "phrase_context":
         classifier = PhraseContextClassifier(embedding_dim=config["model"]["input_dim"],
@@ -45,11 +52,24 @@ def init_classifier(config):
                                             normalize_embeddings=config["model"]["normalize_embeddings"],
                                             pretrained_model=config["pretrained_model_path"],
                                             add_single_words=config["model"]["add_single_words"])
+    if config["model"]["type"] == "matrix_transfer":
+        classifier = MatrixTransferClassifier(input_dim=config["model"]["input_dim"],
+                                              hidden_dim=config["model"]["hidden_size"],
+                                              dropout_rate=config["model"]["dropout"],
+                                              label_nr=config["model"]["label_size"],
+                                              normalize_embeddings=config["model"]["normalize_embeddings"],
+                                              pretrained_model=config["pretrained_model_path"],
+                                              add_single_words=config["model"]["add_single_words"])
+
     if config["model"]["type"] == "transweigh_pretrain":
         classifier = TransweighPretrain(input_dim=config["model"]["input_dim"],
                                         dropout_rate=config["model"]["dropout"],
                                         normalize_embeddings=config["model"]["normalize_embeddings"],
                                         transformations=config["model"]["transformations"])
+    if config["model"]["type"] == "matrix_pretrain":
+        classifier = MatrixPretrain(input_dim=config["model"]["input_dim"],
+                                    dropout_rate=config["model"]["dropout"],
+                                    normalize_embeddings=config["model"]["normalize_embeddings"])
 
     assert classifier, "no valid classifier name specified in the configuration"
     return classifier

--- a/tests/test_matrix_composition_model.py
+++ b/tests/test_matrix_composition_model.py
@@ -1,0 +1,90 @@
+import unittest
+import math
+import pathlib
+import numpy as np
+import json
+import torch
+from torch import optim
+from scripts.data_loader import PretrainCompmodelDataset
+from torch.utils.data import DataLoader
+from scripts import MatrixTwoWordClassifier, MatrixPretrain, MatrixTransferClassifier
+from scripts import training_utils
+from scripts import multi_class_cross_entropy, get_loss_cosine_distance
+
+
+class MatrixCompositionModelTest(unittest.TestCase):
+    """
+    this class tests the matrix composition models
+    This test suite can be ran with:
+        python -m unittest -q tests.MatrixCompositionModelTest
+    """
+
+    def setUp(self):
+        config_static = str(pathlib.Path(__file__).parent.absolute().joinpath("test_configs/simple_phrase_config.json"))
+        data_pretrain = str(pathlib.Path(__file__).parent.absolute().joinpath("data_pretraining/train.txt"))
+        embeddings = str(pathlib.Path(__file__).parent.absolute().joinpath(
+            "embeddings/german-structgram-mincount-30-ctx-10-dims-300.fifu"))
+        with open(config_static, 'r') as f:
+            self.config_static = json.load(f)
+        _, _, self.simple_phrase_test = training_utils.get_datasets(self.config_static)
+        self.data_loader = DataLoader(dataset=self.simple_phrase_test, batch_size=4)
+        self.pretrain_dataset = PretrainCompmodelDataset(data_path=data_pretrain, embedding_path=embeddings,
+                                                         separator=" ", head="head", mod="modifier", phrase="phrase")
+        self.pretrain_loader = DataLoader(dataset=self.pretrain_dataset, batch_size=4)
+
+        self.model_multiclass = MatrixTwoWordClassifier(input_dim=300, hidden_dim=100, label_nr=3,
+                                                        dropout_rate=0.1,
+                                                        normalize_embeddings=True)
+        self.model_pretrain = MatrixPretrain(input_dim=300, dropout_rate=0.1, normalize_embeddings=True)
+        self.train_matrix_classifier()
+        pretrained_model = torch.load("models/matrix_classifier")
+        self.model_transfer = MatrixTransferClassifier(input_dim=300, hidden_dim=100, label_nr=3, dropout_rate=0.1,
+                                                       normalize_embeddings=True, pretrained_model=pretrained_model)
+
+    @staticmethod
+    def acess_named_parameter(model, parameter_name):
+        for name, param in model.named_parameters():
+            if param.requires_grad:
+                if name == parameter_name:
+                    return param.clone()
+
+    def train_matrix_classifier(self):
+        """Auxiliary method to train and save a normal classification matrix model"""
+        optimizer = optim.Adam(self.model_multiclass.parameters())
+        for batch in self.data_loader:
+            optimizer.zero_grad()
+            batch["device"] = "cpu"
+            output = self.model_multiclass(batch)
+            loss = multi_class_cross_entropy(output, batch["l"])
+            loss.backward()
+            optimizer.step()
+        torch.save(self.model_multiclass.state_dict(), "models/matrix_classifier")
+
+    def test_matrix_classifier(self):
+        """Test whether matrix classification model can be used to compute the loss"""
+        batch = next(iter(self.data_loader))
+        batch["device"] = "cpu"
+        output = self.model_multiclass(batch)
+        loss = multi_class_cross_entropy(output, batch["l"]).item()
+        np.testing.assert_equal(math.isnan(loss), False)
+        np.testing.assert_equal(loss >= 0, True)
+
+    def test_matrix_pretrain(self):
+        """Test whether matrix pretraining model can be used to compute the loss and whether the composed
+        representation has the correct shape"""
+        batch = next(iter(self.pretrain_loader))
+        batch["device"] = "cpu"
+        out = self.model_pretrain(batch).squeeze().to("cpu")
+        loss = get_loss_cosine_distance(composed_phrase=out, original_phrase=batch["l"]).item()
+        np.testing.assert_equal(out.shape, [4, 300])
+        np.testing.assert_equal(math.isnan(loss), False)
+        np.testing.assert_equal(loss >= 0, True)
+
+    def test_matrix_transfer(self):
+        """Test whether the transfer matrix classification model can be called and whether the loss can be computed"""
+        batch = next(iter(self.data_loader))
+        batch["device"] = "cpu"
+        output = self.model_transfer(batch)
+        loss = multi_class_cross_entropy(output, batch["l"]).item()
+        np.testing.assert_equal(math.isnan(loss), False)
+        np.testing.assert_equal(loss >= 0, True)


### PR DESCRIPTION
- contains three "models" based on the same composition function..
- two words are combined by multiplying the concatenated input vectors with a matrix that projects them to the embedding dim of a single word embedding (e.g in our case the matrix has dim 600 x 300 for standard fifu embeddings. nonlinearity is applied on top
- two models contain a classification layer on top, one uses pertained weights for the matrix, one trains the matrix from scratch
- one model just returns the composed representation
- test is added that constructs the three classifier and calls the output for each 
- the models can be specified in the config (see training utils)