### PR TITLE
joint training of composition model

### DIFF
--- a/ranking_models/__init__.py
+++ b/ranking_models/__init__.py
@@ -2,3 +2,4 @@ from ranking_models.matrix_transfer_ranking import MatrixTransferRanker
 from ranking_models.transweigh_transfer_ranking import TransweighTransferRanker
 from ranking_models.matrix_pretrain import MatrixPretrain
 from ranking_models.transweigh_pretrain import TransweighPretrain
+from ranking_models.transweigh_joint_ranking import TransweighJointRanker

--- a/ranking_models/transweigh_joint_ranking.py
+++ b/ranking_models/transweigh_joint_ranking.py
@@ -1,0 +1,131 @@
+import torch
+from torch import nn
+from torch.functional import F
+from utils.composition_functions import transweigh
+
+
+class TransweighJointRanker(nn.Module):
+    """
+    This model trains two representations, each containing a different type of semantic content (one for the general
+    phrase and one to be close the the conveyed attribute.
+    """
+
+    def __init__(self, input_dim, dropout_rate, transformations, normalize_embeddings, rep1_weight, rep2_weight):
+        super().__init__()
+
+        # the transformation tensor and bias for transforming the input vectors
+        self._transformation_tensor = nn.Parameter(
+            torch.empty(transformations, 2 * input_dim, input_dim), requires_grad=True)
+        nn.init.xavier_normal_(self.transformation_tensor)
+        self._transformation_bias = nn.Parameter(torch.empty(transformations, input_dim), requires_grad=True)
+        nn.init.uniform_(self.transformation_bias)
+
+        # - the combining tensor for representation 1
+        self._combining_tensor_1 = nn.Parameter(data=torch.empty(transformations, input_dim, input_dim),
+                                                requires_grad=True)
+        nn.init.xavier_normal_(self.combining_tensor_1)
+        self._combining_bias_1 = nn.Parameter(torch.empty(input_dim), requires_grad=True)
+        nn.init.uniform_(self.combining_bias_1)
+
+        # - the combining tensor for representation 2
+        self._combining_tensor_2 = nn.Parameter(data=torch.empty(transformations, input_dim, input_dim),
+                                                requires_grad=True)
+        nn.init.xavier_normal_(self.combining_tensor_2)
+        self._combining_bias_2 = nn.Parameter(torch.empty(input_dim), requires_grad=True)
+        nn.init.uniform_(self.combining_bias_2)
+
+        self._dropout_rate = dropout_rate
+        self._normalize_embeddings = normalize_embeddings
+        self._rep1_weight = rep1_weight
+        self._rep2_weight = rep2_weight
+
+    def forward(self, batch):
+        """
+        Takes a data batch as input that should contain two word vectors. They are composed two times to get two
+        representations. Both composition functions share the transformations but for each representation a different
+        weighting is applied. A final representation is constructed using a weighted summation of both representations.
+        :param batch: a dictionary
+        :return: the final composed phrase, representation 1, representation 2
+        """
+        device = batch["device"]
+        self._representation_1 = self.compose(word1=batch["w1"].to(device), word2=batch["w2"].to(device),
+                                              combinig_tensor=self.combining_tensor_1,
+                                              combining_bias=self.combining_bias_1)
+        self._representation_2 = self.compose(word1=batch["w1"].to(device), word2=batch["w2"].to(device),
+                                              combinig_tensor=self.combining_tensor_2,
+                                              combining_bias=self.combining_bias_2)
+        self._composed_phrase = self.rep1_weight * self.representation_1 + self.rep2_weight * self.representation_2
+        if self.normalize_embeddings:
+            self._composed_phrase = F.normalize(self.composed_phrase, p=2, dim=1)
+        return self.composed_phrase, self.representation_1, self.representation_2
+
+    def compose(self, word1, word2, combinig_tensor, combining_bias):
+        """
+        This functions composes two input representations with the transformation weighting model. If set to True,
+        the composed representation is normalized
+        :param word1: the representation of the first word (torch tensor)
+        :param word2: the representation of the second word (torch tensor)
+        :param combinig_tensor: The tensor used for weighting the transformed input vectors into one representation
+        :param combining_bias: The corresponding bias
+        :return: a composed representation
+        """
+        composed_phrase = transweigh(word1=word1, word2=word2, transformation_tensor=self.transformation_tensor,
+                                     transformation_bias=self.transformation_bias,
+                                     combining_bias=combining_bias,
+                                     combining_tensor=combinig_tensor, dropout_rate=self.dropout_rate,
+                                     training=self.training)
+        if self.normalize_embeddings:
+            composed_phrase = F.normalize(composed_phrase, p=2, dim=1)
+        return composed_phrase
+
+    @property
+    def combining_tensor_1(self):
+        return self._combining_tensor_1
+
+    @property
+    def combining_bias_1(self):
+        return self._combining_bias_1
+
+    @property
+    def combining_tensor_2(self):
+        return self._combining_tensor_2
+
+    @property
+    def combining_bias_2(self):
+        return self._combining_bias_2
+
+    @property
+    def transformation_tensor(self):
+        return self._transformation_tensor
+
+    @property
+    def transformation_bias(self):
+        return self._transformation_bias
+
+    @property
+    def dropout_rate(self):
+        return self._dropout_rate
+
+    @property
+    def normalize_embeddings(self):
+        return self._normalize_embeddings
+
+    @property
+    def composed_phrase(self):
+        return self._composed_phrase
+
+    @property
+    def representation_1(self):
+        return self._representation_1
+
+    @property
+    def representation_2(self):
+        return self._representation_2
+
+    @property
+    def rep1_weight(self):
+        return self._rep1_weight
+
+    @property
+    def rep2_weight(self):
+        return self._rep2_weight

--- a/tests/test_joint_ranking.py
+++ b/tests/test_joint_ranking.py
@@ -1,0 +1,126 @@
+import unittest
+import math
+import pathlib
+import numpy as np
+import torch
+from torch import optim
+from utils import loss_functions
+import torch.nn.functional as F
+from ranking_models import TransweighJointRanker
+from utils.data_loader import PretrainCompmodelDataset, MultiRankingDataset
+from torch.utils.data import DataLoader
+
+
+class JointRankingTest(unittest.TestCase):
+    """
+    this class tests the training utils script
+    This test suite can be ran with:
+        python -m unittest -q tests.JointRankingTest
+    """
+
+    def setUp(self):
+        self._data_path_1 = pathlib.Path(__file__).parent.absolute().joinpath("data_pretraining/train.txt")
+        self._data_path_2 = pathlib.Path(__file__).parent.absolute().joinpath("data_pretraining/test.txt")
+        self._embedding_path = str(pathlib.Path(__file__).parent.absolute().joinpath(
+            "embeddings/german-skipgram-mincount-30-ctx-10-dims-300.fifu"))
+        self._dataset_1 = PretrainCompmodelDataset(self._data_path_1, self._embedding_path, head="head",
+                                                   mod="modifier", phrase="phrase", separator=" ")
+        self._dataset_2 = PretrainCompmodelDataset(self._data_path_2, self._embedding_path, head="head",
+                                                   mod="modifier", phrase="phrase", separator=" ")
+        modifier_embeddings = F.normalize(torch.rand((50, 100)), dim=1)
+        head_embeddings = F.normalize(torch.rand((50, 100)), dim=1)
+        gold_composed = F.normalize(torch.rand((50, 100)), dim=1)
+        device = torch.device("cpu")
+        self.input_1 = {"w1": modifier_embeddings, "w2": head_embeddings, "l": gold_composed, "device": device}
+        self.input_2 = {"w1": modifier_embeddings, "w2": head_embeddings, "l": gold_composed, "device": device}
+        self.model = TransweighJointRanker(input_dim=100, dropout_rate=0.0, normalize_embeddings=True,
+                                           transformations=10, rep1_weight=0.3, rep2_weight=0.7)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=0.1)
+
+    @staticmethod
+    def acess_named_parameter(model, parameter_name):
+        for name, param in model.named_parameters():
+            if param.requires_grad:
+                if name == parameter_name:
+                    return param.clone()
+
+    def test_model_loss(self):
+        """
+        Test whether the composition model can be ran and whether the loss can be computed. The loss should be
+        a number larger than zero and not NaN
+        """
+        self.optimizer.zero_grad()
+        composed, rep_1, rep_2 = self.model(self.input_1)
+        loss_1 = loss_functions.get_loss_cosine_distance(original_phrase=self.input_1["l"], composed_phrase=rep_1,
+                                                         dim=1, normalize=False).item()
+        composed, rep_1, rep_2 = self.model(self.input_2)
+        loss_2 = loss_functions.get_loss_cosine_distance(original_phrase=self.input_1["l"], composed_phrase=rep_2,
+                                                         dim=1, normalize=False).item()
+        np.testing.assert_equal(math.isnan(loss_1), False)
+        np.testing.assert_equal(math.isnan(loss_2), False)
+
+        np.testing.assert_equal(loss_1 >= 0, True)
+        np.testing.assert_equal(loss_2 >= 0, True)
+
+    def test_parameter_get_updated(self):
+        """Test whether initial weight matrices are being updated during training. These parameters should be different
+        after training vs before training."""
+        tw_tensor_before_training = self.acess_named_parameter(self.model, "_transformation_tensor")
+        combining_tensor_1_before_training = self.acess_named_parameter(self.model, "_combining_tensor_1")
+        combining_tensor_2_before_training = self.acess_named_parameter(self.model, "_combining_tensor_2")
+
+        for epoch in range(0, 10):
+            self.optimizer.zero_grad()
+            composed, rep_1, rep_2 = self.model(self.input_1)
+            loss_1 = loss_functions.get_loss_cosine_distance(original_phrase=self.input_1["l"], composed_phrase=rep_1,
+                                                             dim=1, normalize=False)
+            composed, rep_1, rep_2 = self.model(self.input_2)
+            loss_2 = loss_functions.get_loss_cosine_distance(original_phrase=self.input_1["l"], composed_phrase=rep_2,
+                                                             dim=1, normalize=False)
+            loss = loss_1 + loss_2
+            loss.backward()
+            self.optimizer.step()
+            tw_tensor_after_training = self.acess_named_parameter(self.model, "_transformation_tensor")
+            combining_tensor_1_after_training = self.acess_named_parameter(self.model, "_combining_tensor_1")
+            combining_tensor_2_after_training = self.acess_named_parameter(self.model, "_combining_tensor_2")
+        difference_combining_tensor_1 = torch.sum(
+            combining_tensor_1_before_training - combining_tensor_1_after_training).item()
+        difference_combining_tensor_2 = torch.sum(
+            combining_tensor_2_before_training - combining_tensor_2_after_training).item()
+        differemce_combining_tensors = torch.sum(
+            combining_tensor_1_after_training - combining_tensor_2_after_training).item()
+        difference_tw_tensor = torch.sum(tw_tensor_before_training - tw_tensor_after_training).item()
+        np.testing.assert_equal(difference_combining_tensor_1 != 0.0, True)
+        np.testing.assert_equal(difference_combining_tensor_2 != 0.0, True)
+        np.testing.assert_equal(differemce_combining_tensors != 0.0, True)
+        np.testing.assert_equal(difference_tw_tensor != 0.0, True)
+
+    def test_output_shape(self):
+        """Test whether the output shape of the composed representation is as expected"""
+        expected_shape = np.array([50, 100])
+        composed_phrase, rep_1, rep_2 = self.model(self.input_2)
+        np.testing.assert_almost_equal(composed_phrase.shape, expected_shape)
+        np.testing.assert_almost_equal(rep_1.shape, expected_shape)
+        np.testing.assert_almost_equal(rep_2.shape, expected_shape)
+
+    def test_embedding_normalization(self):
+        """Test whether the composed phrase has been normalized to unit norm"""
+        composed_phrase, rep_1, rep_2 = self.model(self.input_2)
+        np.testing.assert_almost_equal(np.linalg.norm(composed_phrase[0].data), 1.0)
+        np.testing.assert_almost_equal(np.linalg.norm(rep_1[0].data), 1.0)
+        np.testing.assert_almost_equal(np.linalg.norm(rep_2[0].data), 1.0)
+
+    def test_dataloader(self):
+        """Test whether the pretrained dataset holds a vector for each instance in batch that has the correct
+        dimension"""
+        multi_dataset = MultiRankingDataset(dataset_1=self._dataset_1, dataset_2=self._dataset_2)
+        dataloader = DataLoader(multi_dataset, batch_size=3, shuffle=True, num_workers=2)
+
+        batch_1, batch_2 = next(iter(dataloader))
+        np.testing.assert_equal(batch_1["w1"].shape, [3, 300])
+        np.testing.assert_equal(batch_1["w2"].shape, [3, 300])
+        np.testing.assert_equal(batch_1["l"].shape, [3, 300])
+
+        np.testing.assert_equal(batch_2["w1"].shape, [3, 300])
+        np.testing.assert_equal(batch_2["w2"].shape, [3, 300])
+        np.testing.assert_equal(batch_2["l"].shape, [3, 300])

--- a/training_scripts/joint_training.py
+++ b/training_scripts/joint_training.py
@@ -1,0 +1,336 @@
+import argparse
+import time
+import json
+from pathlib import Path
+import logging.config
+from utils.logger_config import create_config
+import numpy as np
+import torch
+from torch import optim
+from torch.utils.data import DataLoader
+from utils.training_utils import init_classifier, get_datasets
+from utils.data_loader import extract_all_labels, extract_all_words
+from utils.loss_functions import get_loss_cosine_distance
+from training_scripts.nearest_neighbour import NearestNeigbourRanker
+from utils.data_loader import MultiRankingDataset, PretrainCompmodelDataset
+from tqdm import trange
+
+
+def pretrain(pretrain_loader, model, optimizer):
+    """
+    This function trains the model for one epoch on a given training set
+    :param pretrain_loader: a dataloader that contains a specific training set
+    :param model: the classifier
+    :param optimizer: the optimizer
+    :return: trained classifier and optimizer
+    """
+    pbar = trange(100, desc='Pretrain for one epoch...', leave=True)
+    for batch in pretrain_loader:
+        batch["device"] = device
+        composed, rep1, rep2 = model(batch)
+        phrase_loss = get_loss_cosine_distance(composed_phrase=rep1, original_phrase=batch["l"])
+        phrase_loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+        pbar.update(100 / len(pretrain_loader))
+    return model, optimizer
+
+
+def train(config, pretrain_loader, train_loader, valid_loader_1, valid_loader_2, model_path, device):
+    """
+    This method trains a composition model jointly on two tasks. On top of that, the model is pretrained on the more
+    general / harder task.
+    :param config: the main configuration with the settings that should be used for training
+    :param pretrain_loader: a dataloader with the dataset that should be used for pretraining
+    :param train_loader: a trainloader that contains a "MultiRankingDataset". This returns two batches, each batch
+    contains the instances of one of the two datasets
+    :param valid_loader_1: the validation dataset loader of the first task (phrase reconstruction)
+    :param valid_loader_2: the validation dataset loader of the second task (attribute composition)
+    :param model_path: the path to save the model to
+    :param device: the device type (CPU or GPU)
+    """
+    model = init_classifier(config)
+    model.to(device)
+    optimizer = optim.Adam(model.parameters())
+    current_patience = 0
+    tolerance = 1e-5
+    lowest_loss = float("inf")
+    best_epoch = 1
+    epoch = 1
+    train_loss = 0.0
+    model, optimizer = pretrain(pretrain_loader, model, optimizer)
+    for epoch in range(1, config["num_epochs"] + 1):
+        model.train()
+        train_losses = []
+        valid_losses_attribute = []
+        valid_losses_phrase = []
+        for batch_task_1, batch_task_2 in train_loader:
+            batch_task_1["device"] = device
+            batch_task_2["device"] = device
+
+            composed, rep1, rep2 = model(batch_task_1)
+            rep1 = rep1.squeeze().to("cpu")
+            phrase_loss = get_loss_cosine_distance(composed_phrase=rep1, original_phrase=batch_task_1["l"])
+
+            composed, rep1, rep2 = model(batch_task_2)
+            rep2 = rep2.squeeze().to("cpu")
+            attribute_loss = get_loss_cosine_distance(composed_phrase=rep2, original_phrase=batch_task_2["l"])
+
+            loss = attribute_loss + phrase_loss
+            loss.backward()
+            optimizer.step()
+            optimizer.zero_grad()
+            train_losses.append(loss.item())
+        for batch in valid_loader_1:
+            model.eval()
+            batch["device"] = device
+            _, out, _ = model(batch)
+            out = out.squeeze().to("cpu")
+            loss = get_loss_cosine_distance(composed_phrase=out, original_phrase=batch["l"])
+            valid_losses_phrase.append(loss.item())
+        for batch in valid_loader_2:
+            batch["device"] = device
+            _, _, out = model(batch)
+            out = out.squeeze().to("cpu")
+            loss = get_loss_cosine_distance(composed_phrase=out, original_phrase=batch["l"])
+            valid_losses_attribute.append(loss.item())
+
+        # calculate average loss and accuracy over an epoch
+        train_loss = np.average(train_losses)
+        valid_loss_label = np.average(valid_losses_attribute)
+        valid_loss_phrase = np.average(valid_losses_phrase)
+        total_valid_loss = (valid_loss_label + valid_loss_phrase) / 2
+
+        if lowest_loss - total_valid_loss > tolerance:
+            lowest_loss = total_valid_loss
+            best_epoch = epoch
+            current_patience = 0
+            torch.save(model.state_dict(), model_path)
+        else:
+            current_patience += 1
+        if current_patience > config["patience"]:
+            break
+
+        logger.info(
+            "current patience: %d , epoch %d , train loss: %.3f, validation loss task 1: %.3f, validation loss task "
+            "2: %.3f" %
+            (current_patience, epoch, train_loss, valid_loss_label, valid_loss_phrase))
+    logger.info(
+        "training finnished after %d epochs, train loss: %.5f, best epoch : %d , best validation loss: %.5f" %
+        (epoch, train_loss, best_epoch, lowest_loss))
+
+
+def predict(test_loader, model, device):
+    """
+    predicts labels on unseen data (test set)
+    :param test_loader: dataloader torch object with test- or validation data
+    :param model: trained model
+    :param device: the device
+    :return: predictions and losses for the learned attribute and the final composed representation, the original phrases
+    """
+    test_loss_att = []
+    test_loss_final = []
+    predictions_final_rep = []
+    predictions_attribute_rep = []
+    orig_phrases = []
+    model.to(device)
+    for batch in test_loader:
+        batch["device"] = device
+        composed, rep1, rep2 = model(batch)
+        composed = composed.squeeze().to("cpu")
+        rep2 = rep2.squeeze().to("cpu")
+        for pred in rep2:
+            predictions_attribute_rep.append(pred.detach().numpy())
+        for pred in composed:
+            predictions_final_rep.append(pred.detach().numpy())
+        loss_att = get_loss_cosine_distance(composed_phrase=rep2, original_phrase=batch["l"])
+        loss_final = get_loss_cosine_distance(composed_phrase=composed, original_phrase=batch["l"])
+        test_loss_att.append(loss_att.item())
+        test_loss_final.append(loss_final.item())
+        orig_phrases.append(batch["phrase"])
+    orig_phrases = [item for sublist in orig_phrases for item in sublist]
+    predictions_final_rep = np.array(predictions_final_rep)
+    predictions_attribute_rep = np.array(predictions_attribute_rep)
+    return predictions_final_rep, predictions_attribute_rep, np.average(test_loss_final), np.average(
+        test_loss_att), orig_phrases
+
+
+def save_predictions(predictions, path):
+    """Save the predicted representations as numpy arrays"""
+    np.save(file=path, arr=predictions, allow_pickle=True)
+
+
+def get_save_path(model_path, split, representation_type):
+    """
+    Construct two paths (as strings) to save the predictions and ranks to
+    :param model path: the base model path
+    :param split: either dev or test
+    :param representation_type: either "final_rep" or "attribute_rep"
+    """
+    prediction_path = model_path + representation_type + "_" + split + "predictions.npy"
+    rank_path = model_path + representation_type + "_" + split + "ranks.npy"
+    return prediction_path, rank_path
+
+
+def evaluate(predictions_final_phrase, predictions_att_rep, ranks_final_phrase, ranks_att_rep, dataset, labels, config):
+    """
+    Load nearest neighbour ranker for each representation type and log the corresponding results
+    :param predictions_final_phrase: the predicted representations (the final composed phrase)
+    :param predictions_att_rep: the predicted representations (the attribute-specific representation)
+    :param ranks_final_phrase: the path to save the ranks to (for final phrase)
+    :param ranks_att_rep: the path to save the ranks to (for the attribute)
+    :param dataset: the dataset to evaluate on
+    :param labels: all possible labels that can be predicted
+    :param config: the configuration that corresponds to the data
+    """
+    rank_loader = torch.utils.data.DataLoader(dataset, batch_size=len(dataset), num_workers=0,
+                                              shuffle=False)
+    ranker_attribute = NearestNeigbourRanker(path_to_predictions=predictions_att_rep,
+                                             embedding_path=config["feature_extractor"]["static"][
+                                                 "pretrained_model"], data_loader=rank_loader,
+                                             all_labels=labels,
+                                             y_label="phrase", max_rank=1000)
+    ranker_attribute.save_ranks(ranks_att_rep)
+    ranker_final_rep = NearestNeigbourRanker(path_to_predictions=predictions_final_phrase,
+                                             embedding_path=config["feature_extractor"]["static"][
+                                                 "pretrained_model"], data_loader=rank_loader,
+                                             all_labels=labels,
+                                             y_label="phrase", max_rank=1000)
+    ranker_final_rep.save_ranks(ranks_final_phrase)
+
+    logger.info(("result for learned attribute representation"))
+    logger.info(ranker_attribute.result)
+    logger.info("quartiles : %s" % str(ranker_attribute.quartiles))
+    logger.info(
+        "precision at rank 1: %.2f; precision at rank 5 %.2f" % (ranker_attribute._map_1, ranker_attribute._map_5))
+    logger.info("accuracy: %.2f; f1 score: %.2f" % (ranker_attribute.accuracy, ranker_attribute.f1))
+
+    logger.info(("\nresult for final representation"))
+    logger.info(ranker_final_rep.result)
+    logger.info("quartiles : %s" % str(ranker_final_rep.quartiles))
+    logger.info(
+        "precision at rank 1: %.2f; precision at rank 5 %.2f" % (ranker_final_rep._map_1, ranker_final_rep._map_5))
+    logger.info("accuracy: %.2f; f1 score: %.2f" % (ranker_final_rep.accuracy, ranker_final_rep.f1))
+
+
+if __name__ == "__main__":
+
+    argp = argparse.ArgumentParser()
+    argp.add_argument("path_to_config_1")
+    argp.add_argument("path_to_config_2")
+    argp = argp.parse_args()
+
+    with open(argp.path_to_config_1, 'r') as f:
+        config_1 = json.load(f)
+    with open(argp.path_to_config_2, 'r') as f:
+        config_2 = json.load(f)
+
+    ts = time.gmtime()
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # all save paths are picked based on the first configuration
+    if config_1["save_name"] == "":
+        save_name = format(
+            "%s_%s" % (config_1["model"]["type"], time.strftime("%Y-%m-%d-%H_%M_%S", ts)))
+    else:
+        save_name = format("%s_%s" % (config_1["save_name"], time.strftime("%Y-%m-%d-%H_%M_%S", ts)))
+    log_file = str(Path(config_1["logging_path"]).joinpath(save_name + "_log.txt"))
+    model_path = str(Path(config_1["model_path"]).joinpath(save_name))
+
+    prediction_path_dev_final_rep, rank_path_dev_final_rep = get_save_path(model_path, "_final_rep", "dev")
+    prediction_path_test_final_rep, rank_path_test_final_rep = get_save_path(model_path, "_final_rep", "test")
+
+    prediction_path_dev_attribute_rep, rank_path_dev_attribute_rep = get_save_path(model_path, "_attribute_rep", "dev")
+    prediction_path_test_attribute_rep, rank_path_test_attribute_rep = get_save_path(model_path, "_attribute_rep",
+                                                                                     "test")
+
+    logging.config.dictConfig(create_config(log_file))
+    logger = logging.getLogger("train")
+    logger.info("Training a joint model with the following parameter for the first dataset: %s" % str(config_1))
+    logger.info("The following parameter for the second dataset: %s" % str(config_2))
+
+    # set random seed
+    np.random.seed(config_1["seed"])
+    # create two PretrainCompModel datasets
+    dataset_train_1, dataset_valid_1, dataset_test_1 = get_datasets(config_1)
+    dataset_train_2, dataset_valid_2, dataset_test_2 = get_datasets(config_2)
+
+    assert type(dataset_train_1) == PretrainCompmodelDataset and type(
+        dataset_train_2) == PretrainCompmodelDataset, "the dataset type is invalid for this kind of training"
+
+    labels_dataset_1 = extract_all_words(training_data=config_1["train_data_path"],
+                                         validation_data=config_1["validation_data_path"],
+                                         test_data=config_1["test_data_path"],
+                                         separator=config_1["data_loader"]["separator"],
+                                         modifier=config_1["data_loader"]["modifier"],
+                                         head=config_1["data_loader"]["head"],
+                                         phrase=config_1["data_loader"]["phrase"])
+    labels_dataset_2 = extract_all_labels(training_data=config_2["train_data_path"],
+                                          validation_data=config_2["validation_data_path"],
+                                          test_data=config_2["test_data_path"],
+                                          separator=config_2["data_loader"]["separator"]
+                                          , label=config_2["data_loader"]["phrase"])
+
+    # load data with torch Data Loader
+    combined_dataset = MultiRankingDataset(dataset_train_1, dataset_train_2)
+    train_loader = DataLoader(combined_dataset,
+                              batch_size=config_1["iterator"]["batch_size"],
+                              shuffle=True,
+                              num_workers=0)
+    # use one training set for pretraining
+    pretrain_loader = DataLoader(dataset_train_1, batch_size=config_1["iterator"]["batch_size"],
+                                 shuffle=True,
+                                 num_workers=0)
+
+    # load validation data in batches
+    valid_loader_1 = torch.utils.data.DataLoader(dataset_valid_1,
+                                                 batch_size=config_1["iterator"]["batch_size"],
+                                                 shuffle=False,
+                                                 num_workers=0)
+    valid_loader_2 = torch.utils.data.DataLoader(dataset_valid_2, batch_size=len(dataset_valid_2), num_workers=0,
+                                                 shuffle=False)
+
+    model = None
+    y_label = None
+    # train
+    train(config=config_1, pretrain_loader=pretrain_loader, train_loader=train_loader, valid_loader_1=valid_loader_1,
+          valid_loader_2=valid_loader_2, device=device, model_path=model_path)
+    # test and & evaluate
+    logger.info("Loading best model from %s", model_path)
+    valid_model = init_classifier(config_1)
+    valid_model.load_state_dict(torch.load(model_path))
+    valid_model.eval()
+
+    if valid_model:
+        logger.info("generating predictions for validation data...")
+        valid_predictions_final_phrase, valid_predictions_att, valid_loss_final, valid_loss_att, valid_phrases = \
+            predict(
+                valid_loader_2,
+                valid_model, device)
+        save_predictions(predictions=valid_predictions_final_phrase, path=prediction_path_dev_final_rep)
+        save_predictions(predictions=valid_predictions_att, path=prediction_path_dev_attribute_rep)
+        logger.info("saved predictions to %s" % prediction_path_dev_final_rep)
+        logger.info("saved predictions to %s" % prediction_path_dev_attribute_rep)
+        logger.info("validation loss att: %.5f" % valid_loss_att)
+        logger.info("validation loss final phrase: %.5f" % valid_loss_final)
+        evaluate(predictions_final_phrase=prediction_path_dev_final_rep,
+                 predictions_att_rep=prediction_path_dev_attribute_rep, ranks_final_phrase=rank_path_dev_final_rep,
+                 ranks_att_rep=rank_path_dev_attribute_rep, dataset=dataset_valid_2, labels=labels_dataset_2,
+                 config=config_2)
+    # do evaluation on test set if argument set to true
+    if config_1["eval_on_test"]:
+        logger.info("generating predictions for test data...")
+        test_loader = torch.utils.data.DataLoader(dataset_test_2, batch_size=len(dataset_test_2), num_workers=0,
+                                                  shuffle=False)
+        test_predictions_final_phrase, test_predictions_att, test_loss_final, test_loss_att, test_phrases = predict(
+            test_loader, valid_model, device)
+        save_predictions(predictions=test_predictions_final_phrase, path=prediction_path_test_final_rep)
+        save_predictions(predictions=test_predictions_att, path=prediction_path_test_attribute_rep)
+        logger.info("saved predictions to %s" % prediction_path_test_final_rep)
+        logger.info("saved predictions to %s" % prediction_path_test_attribute_rep)
+        logger.info("validation loss att: %.5f" % test_loss_att)
+        logger.info("validation loss final phrase: %.5f" % test_loss_final)
+        evaluate(predictions_final_phrase=prediction_path_test_final_rep,
+                 predictions_att_rep=prediction_path_test_attribute_rep, ranks_final_phrase=rank_path_test_final_rep,
+                 ranks_att_rep=rank_path_test_attribute_rep, dataset=dataset_test_2, labels=labels_dataset_2,
+                 config=config_2)

--- a/utils/data_loader.py
+++ b/utils/data_loader.py
@@ -406,7 +406,9 @@ class MultiRankingDataset(Dataset):
         self._dataset_2 = dataset_2
 
     def __len__(self):
-        return len(self.dataset_2)
+        if len(self.dataset_2) < len(self.dataset_1):
+            return len(self.dataset_2)
+        return len(self.dataset_1)
 
     def __getitem__(self, idx):
         """Returns a batch for each dataset"""

--- a/utils/data_loader.py
+++ b/utils/data_loader.py
@@ -394,3 +394,30 @@ class PretrainCompmodelDataset(Dataset):
     @property
     def samples(self):
         return self._samples
+
+
+class MultiRankingDataset(Dataset):
+    """
+    This dataset can be used to combine two different dataset into one. The datasets need to be of the same type.
+    """
+    def __init__(self, dataset_1, dataset_2):
+        assert type(dataset_1) == type(dataset_2), "cannot combine two datasets of different types"
+        self._dataset_1 = dataset_1
+        self._dataset_2 = dataset_2
+
+    def __len__(self):
+        return len(self.dataset_2)
+
+    def __getitem__(self, idx):
+        """Returns a batch for each dataset"""
+        task1 = self.dataset_1[idx]
+        task2 = self.dataset_2[idx]
+        return task1, task2
+
+    @property
+    def dataset_1(self):
+        return self._dataset_1
+
+    @property
+    def dataset_2(self):
+        return self._dataset_2

--- a/utils/training_utils.py
+++ b/utils/training_utils.py
@@ -1,7 +1,8 @@
 import torch
 from classification_models import BasicTwoWordClassifier, TransweighTwoWordClassifier, TransferCompClassifier, \
     PhraseContextClassifier, MatrixTwoWordClassifier, MatrixTransferClassifier
-from ranking_models import TransweighPretrain, MatrixPretrain, MatrixTransferRanker, TransweighTransferRanker
+from ranking_models import TransweighPretrain, MatrixPretrain, MatrixTransferRanker, TransweighTransferRanker, \
+    TransweighJointRanker
 
 from utils import SimplePhraseContextualizedDataset, SimplePhraseStaticDataset, \
     PhraseAndContextDatasetStatic, PhraseAndContextDatasetBert, PretrainCompmodelDataset
@@ -78,6 +79,15 @@ def init_classifier(config):
         classifier = MatrixPretrain(input_dim=config["model"]["input_dim"],
                                     dropout_rate=config["model"]["dropout"],
                                     normalize_embeddings=config["model"]["normalize_embeddings"])
+    if config["model"]["type"] == "joint_ranking":
+        assert config["model"]["task_weights"][0] + config["model"]["task_weights"][
+            1] == 1.0, "the task weights have to sum to 1"
+        classifier = TransweighJointRanker(input_dim=config["model"]["input_dim"],
+                                           dropout_rate=config["model"]["dropout"],
+                                           normalize_embeddings=config["model"]["normalize_embeddings"],
+                                           transformations=config["model"]["transformations"],
+                                           rep1_weight=config["model"]["task_weights"][0],
+                                           rep2_weight=config["model"]["task_weights"][1])
 
     assert classifier, "no valid classifier name specified in the configuration"
     return classifier


### PR DESCRIPTION
This PR contains the functionality to jointly train a composition model on two tasks. The model takes as input two words and constructs three representations. for example:
word1: hot
word2: weather

the vectors for "hot" and "temperature" are transformed by a number of matrices and result in the same number of transformed vectors
representation 1: separate weighting combines the transformed vectors into representation 1: this representation is trained to be close to the original phrase (gold(hot_ weather)) 
representation 2: separate weighting combines the transformed vectors into representation 2: this representation is trained to be close to the implicit relation /attribute that holds between hot in weather which is temperature
composed: representation 1 and 2 are combined into a final representation by weighting each and adding them (and then normalizing them). Thus, this representation should capture the general meaning of the phrase but also the implicit attribute

we compute two losses:
loss 1: cosine distance(representation 1 , original phrase representation)
loss 2: cosine distance(representation 2, attribute)
we back propagate based on the combined loss (loss 1 + loss 2). 
--> those could be weighted but when I ran the model the losses for both tasks were more or less balanced (the one for phrase reconstruction was a bit lower)

I added one epoch of pretraining because the reconstruction task theoretically has a lot more different labels to lean and thus,  is more complicated. This could be optional or even left out if there is not a big difference but I would do that in a second PR

I currently evaluate the model on attribute ranking based on the nearest neighbor ranker. I report the result for representation 2 (attribute specific representation) as well as for the final representation. It might make sense to add representation 1 as well later on.

To train the model I needed to add a new dataset type but it is very simple. it takes two datasets and returns a batch for each, so that when you iterate in training you get two batches at the same time, one contains phrases with attributes and one phrases with phrase representations. I compute loss one for the phrase batch and loss 2 for the attribute batch and use these losses to backpropagate

a test is added as well.

the PR is very long, especially the training script, so take your time to review it. 

- we probably want to add a simpler model (matrix) model as a joint model as well. but we can do that in a second PR....