### PR TITLE
Joint matrix model

### DIFF
--- a/ranking_models/__init__.py
+++ b/ranking_models/__init__.py
@@ -3,3 +3,4 @@ from ranking_models.transweigh_transfer_ranking import TransweighTransferRanker
 from ranking_models.matrix_pretrain import MatrixPretrain
 from ranking_models.transweigh_pretrain import TransweighPretrain
 from ranking_models.transweigh_joint_ranking import TransweighJointRanker
+from ranking_models.matrix_joint_ranking import MatrixJointRanker

--- a/ranking_models/matrix_joint_ranking.py
+++ b/ranking_models/matrix_joint_ranking.py
@@ -1,0 +1,112 @@
+import torch.nn as nn
+import torch.nn.functional as F
+import utils.composition_functions as comp_functions
+
+
+class MatrixJointRanker(nn.Module):
+    """
+    This model trains two representations, each containing a different type of semantic content (one for the general
+    phrase and one to be close the the conveyed attribute). Both representations are combined into one representation.
+    The model is a basic matrix composition model with two specific linear transformation for each type of semantic representation.
+    """
+
+    def __init__(self, input_dim, dropout_rate, normalize_embeddings, rep1_weight,
+                 rep2_weight):
+        """
+        :param input_dim: embedding dimension
+        :param dropout_rate: dropout rate for regularization
+        :param normalize_embeddings: whether the composed representation should be normalized to unit length
+        :param rep1_weight: weight for representation 1 for final representation
+        :param rep2_weight: weight for representation 2 for final representation
+        """
+        super(MatrixJointRanker, self).__init__()
+        self._matrix_layer = nn.Linear(input_dim * 2, input_dim)
+        self._specific_matrix_1 = nn.Linear(input_dim, input_dim)
+        self._specific_matrix_2 = nn.Linear(input_dim, input_dim)
+        self._dropout_rate = dropout_rate
+        self._normalize_embeddings = normalize_embeddings
+        self._rep1_weight = rep1_weight
+        self._rep2_weight = rep2_weight
+
+    def forward(self, batch):
+        """
+        Takes a data batch as input that contains two word vectors. It applies the same matrix to compose the two vectors.
+        on top of that, two further linear transformations are applied to generate specific representations: one that should
+        look like the phrase and one that should resemble the attribute.
+        :param batch: a dictionary
+        :return: the final composed phrase, representation 1, representation 2
+        """
+        device = batch["device"]
+        self._composed_phrase = self.compose(batch["w1"].to(device), batch["w2"].to(device))
+        self._representation_1 = self._specific_matrix_1(self._composed_phrase)
+        self._representation_2 = self._specific_matrix_2(self._composed_phrase)
+        if self.normalize_embeddings:
+            self._representation_1 = F.normalize(self._representation_1, p=2, dim=1)
+            self._representation_2 = F.normalize(self._representation_2, p=2, dim=1)
+
+        self._final_composed_phrase = self.rep1_weight * self.representation_1 + self.rep2_weight * self.representation_2
+
+        if self.normalize_embeddings:
+            self._final_composed_phrase = F.normalize(self._final_composed_phrase, p=2, dim=1)
+            self._representation_1 = F.normalize(self._representation_1, p=2, dim=1)
+            self._representation_2 = F.normalize(self._representation_2, p=2, dim=1)
+
+        return self.final_composed_phrase, self.representation_1, self.representation_2
+
+    def compose(self, word1, word2):
+        """
+        this function takes two words, concatenates them and applies linear transformation
+        :param word1: the first word of size batch_size x embedding size
+        :param word2: the first word of size batch_size x embedding size
+        :return: the composed representation
+        """
+        composed_phrase = comp_functions.concat(word1, word2, axis=1)
+        transformed = self.matrix_layer(composed_phrase)
+        reg_transformed = F.dropout(transformed, p=self.dropout_rate)
+        if self.normalize_embeddings:
+            reg_transformed = F.normalize(reg_transformed, p=2, dim=1)
+        return reg_transformed
+
+    @property
+    def matrix_layer(self):
+        return self._matrix_layer
+
+    @property
+    def specific_matrix1(self):
+        return self._specific_matrix_1
+
+    @property
+    def specific_matrix2(self):
+        return self._specific_matrix_2
+
+    @property
+    def final_composed_phrase(self):
+        return self._final_composed_phrase
+
+    @property
+    def dropout_rate(self):
+        return self._dropout_rate
+
+    @property
+    def normalize_embeddings(self):
+        return self._normalize_embeddings
+
+    @property
+    def composed_phrase(self):
+        return self._composed_phrase
+
+    @property
+    def representation_1(self):
+        return self._representation_1
+
+    @property
+    def representation_2(self):
+        return self._representation_2
+
+    @property
+    def rep1_weight(self):
+        return self._rep1_weight
+
+    @property
+    def rep2_weight(self):
+        return self._rep2_weight

--- a/tests/test_joint_matrix_ranking.py
+++ b/tests/test_joint_matrix_ranking.py
@@ -1,0 +1,118 @@
+import unittest
+import math
+import pathlib
+import numpy as np
+import torch
+from torch import optim
+from utils import loss_functions
+import torch.nn.functional as F
+from ranking_models import MatrixJointRanker
+from utils.data_loader import PretrainCompmodelDataset, MultiRankingDataset
+from torch.utils.data import DataLoader
+
+
+class JointMatrixRanking(unittest.TestCase):
+    """
+    this class tests the joint matrix model
+    This test suite can be ran with:
+        python -m unittest -q tests.JointRankingTest
+    """
+
+    def setUp(self):
+        self._data_path_1 = pathlib.Path(__file__).parent.absolute().joinpath("data_pretraining/train.txt")
+        self._data_path_2 = pathlib.Path(__file__).parent.absolute().joinpath("data_pretraining/test.txt")
+        self._embedding_path = str(pathlib.Path(__file__).parent.absolute().joinpath(
+            "embeddings/german-skipgram-mincount-30-ctx-10-dims-300.fifu"))
+        self._dataset_1 = PretrainCompmodelDataset(self._data_path_1, self._embedding_path, head="head",
+                                                   mod="modifier", phrase="phrase", separator=" ")
+        self._dataset_2 = PretrainCompmodelDataset(self._data_path_2, self._embedding_path, head="head",
+                                                   mod="modifier", phrase="phrase", separator=" ")
+        modifier_embeddings = F.normalize(torch.rand((50, 100)), dim=1)
+        head_embeddings = F.normalize(torch.rand((50, 100)), dim=1)
+        gold_composed = F.normalize(torch.rand((50, 100)), dim=1)
+        device = torch.device("cpu")
+        self.input_1 = {"w1": modifier_embeddings, "w2": head_embeddings, "l": gold_composed, "device": device}
+        self.input_2 = {"w1": modifier_embeddings, "w2": head_embeddings, "l": gold_composed, "device": device}
+        self.model = MatrixJointRanker(input_dim=100, dropout_rate=0.0, normalize_embeddings=True,
+                                       rep1_weight=0.3, rep2_weight=0.7)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=0.1)
+
+    @staticmethod
+    def access_named_parameter(model, parameter_name):
+        for name, param in model.named_parameters():
+            if param.requires_grad:
+                if name == parameter_name:
+                    return param.clone()
+
+    def test_model_loss(self):
+        self.optimizer.zero_grad()
+        composed, rep_1, rep_2 = self.model(self.input_1)
+        loss_1 = loss_functions.get_loss_cosine_distance(original_phrase=self.input_1["l"], composed_phrase=rep_1,
+                                                         dim=1, normalize=False).item()
+        composed, rep_1, rep_2 = self.model(self.input_2)
+        loss_2 = loss_functions.get_loss_cosine_distance(original_phrase=self.input_1["l"], composed_phrase=rep_2,
+                                                         dim=1, normalize=False).item()
+        np.testing.assert_equal(math.isnan(loss_1), False)
+        np.testing.assert_equal(math.isnan(loss_2), False)
+
+        np.testing.assert_equal(loss_1 >= 0, True)
+        np.testing.assert_equal(loss_2 >= 0, True)
+
+    def test_parameter_updated_with_training(self):
+        matrix_layer_before_training = self.access_named_parameter(self.model, "_matrix_layer.weight")
+        sp_matrix_1_before_training = self.access_named_parameter(self.model, "_specific_matrix_1.weight")
+        sp_matrix_2_before_training = self.access_named_parameter(self.model, "_specific_matrix_2.weight")
+        for epoch in range(0,5):
+            self.optimizer.zero_grad()
+            composed, rep_1, rep_2 = self.model(self.input_1)
+            loss_1 = loss_functions.get_loss_cosine_distance(original_phrase=self.input_1["l"], composed_phrase=rep_1,
+                                                             dim=1, normalize=False)
+            composed, rep_1, rep_2 = self.model(self.input_2)
+            loss_2 = loss_functions.get_loss_cosine_distance(original_phrase=self.input_1["l"], composed_phrase=rep_2,
+                                                             dim=1, normalize=False)
+            loss = loss_1 + loss_2
+            loss.backward()
+            self.optimizer.step()
+            matrix_layer_after_training  = self.access_named_parameter(self.model, "_matrix_layer.weight")
+            sp_matrix_1_after_training = self.access_named_parameter(self.model, "_specific_matrix_1.weight")
+            sp_matrix_2_after_training = self.access_named_parameter(self.model, "_specific_matrix_2.weight")
+        difference_matrix_layer = torch.sum(
+            matrix_layer_before_training - matrix_layer_after_training).item()
+        difference_sp_matrix_1 = torch.sum(
+            sp_matrix_1_before_training - sp_matrix_1_after_training).item()
+        difference_sp_matrix_2 = torch.sum(
+            sp_matrix_2_before_training - sp_matrix_2_after_training).item()
+
+        np.testing.assert_equal(difference_matrix_layer != 0.0, True)
+        np.testing.assert_equal(difference_sp_matrix_1 != 0.0, True)
+        np.testing.assert_equal(difference_sp_matrix_2 != 0.0, True)
+
+
+    def test_output_shape(self):
+        expected_shape = np.array([50, 100])
+        composed_phrase, rep_1, rep_2 = self.model(self.input_2)
+        np.testing.assert_almost_equal(composed_phrase.shape, expected_shape)
+        np.testing.assert_almost_equal(rep_1.shape, expected_shape)
+        np.testing.assert_almost_equal(rep_2.shape, expected_shape)
+
+    def test_embedding_normalization(self):
+        """Test whether the composed phrase has been normalized to unit norm"""
+        composed_phrase, rep_1, rep_2 = self.model(self.input_2)
+        np.testing.assert_almost_equal(np.linalg.norm(composed_phrase[0].data), 1.0)
+        np.testing.assert_almost_equal(np.linalg.norm(rep_1[0].data), 1.0)
+        np.testing.assert_almost_equal(np.linalg.norm(rep_2[0].data), 1.0)
+
+    def test_dataloader(self):
+        """Test whether the pretrained dataset holds a vector for each instance in batch that has the correct
+        dimension"""
+        multi_dataset = MultiRankingDataset(dataset_1=self._dataset_1, dataset_2=self._dataset_2)
+        dataloader = DataLoader(multi_dataset, batch_size=3, shuffle=True, num_workers=2)
+
+        batch_1, batch_2 = next(iter(dataloader))
+        np.testing.assert_equal(batch_1["w1"].shape, [3, 300])
+        np.testing.assert_equal(batch_1["w2"].shape, [3, 300])
+        np.testing.assert_equal(batch_1["l"].shape, [3, 300])
+
+        np.testing.assert_equal(batch_2["w1"].shape, [3, 300])
+        np.testing.assert_equal(batch_2["w2"].shape, [3, 300])
+        np.testing.assert_equal(batch_2["l"].shape, [3, 300])

--- a/utils/training_utils.py
+++ b/utils/training_utils.py
@@ -2,7 +2,7 @@ import torch
 from classification_models import BasicTwoWordClassifier, TransweighTwoWordClassifier, TransferCompClassifier, \
     PhraseContextClassifier, MatrixTwoWordClassifier, MatrixTransferClassifier
 from ranking_models import TransweighPretrain, MatrixPretrain, MatrixTransferRanker, TransweighTransferRanker, \
-    TransweighJointRanker
+    TransweighJointRanker, MatrixJointRanker
 
 from utils import SimplePhraseContextualizedDataset, SimplePhraseStaticDataset, \
     PhraseAndContextDatasetStatic, PhraseAndContextDatasetBert, PretrainCompmodelDataset
@@ -86,6 +86,14 @@ def init_classifier(config):
                                            dropout_rate=config["model"]["dropout"],
                                            normalize_embeddings=config["model"]["normalize_embeddings"],
                                            transformations=config["model"]["transformations"],
+                                           rep1_weight=config["model"]["task_weights"][0],
+                                           rep2_weight=config["model"]["task_weights"][1])
+    if config["model"]["type"] == "joint_ranking_matrix":
+        assert config["model"]["task_weights"][0] + config["model"]["task_weights"][
+            1] == 1.0, "the task weights have to sum to 1"
+        classifier = MatrixJointRanker(input_dim=config["model"]["input_dim"],
+                                           dropout_rate=config["model"]["dropout"],
+                                           normalize_embeddings=config["model"]["normalize_embeddings"],
                                            rep1_weight=config["model"]["task_weights"][0],
                                            rep2_weight=config["model"]["task_weights"][1])
 


### PR DESCRIPTION
This PR contains a joint matrix model. It is basically the same as the transweigh joint model but implements a simple matrix composition function:  Each phrase is composed by a normal matrix model. The phrase is then again transformed by two matrices simultaneously: one of which should resemble the attribute and the other should resemble the reconstructed phrase. 
A test was added and the init files were changed accordingly. 