### PR TITLE
Full additive joint

### DIFF
--- a/ranking_models/__init__.py
+++ b/ranking_models/__init__.py
@@ -5,3 +5,4 @@ from ranking_models.transweigh_pretrain import TransweighPretrain
 from ranking_models.transweigh_joint_ranking import TransweighJointRanker
 from ranking_models.matrix_joint_ranking import MatrixJointRanker
 from ranking_models.full_additive import FullAdditive
+from ranking_models.full_additive_joint_ranking import FullAdditiveJointRanker

--- a/ranking_models/full_additive.py
+++ b/ranking_models/full_additive.py
@@ -6,7 +6,7 @@ import utils.composition_functions as comp_functions
 
 class FullAdditive(nn.Module):
 
-    def __init__(self, input_dim, dropout_rate, normalize_embeddings):
+    def __init__(self, input_dim, normalize_embeddings):
         """
         This class contains the full additive composition model that can be used to train a model with the cosine
         distance loss
@@ -19,7 +19,6 @@ class FullAdditive(nn.Module):
         self._adj_matrix = nn.Parameter(torch.eye(input_dim), requires_grad=True)
         self._noun_matrix = nn.Parameter(torch.eye(input_dim), requires_grad=True)
 
-        self._dropout_rate = dropout_rate
         self._normalize_embeddings = normalize_embeddings
 
     def forward(self, batch):
@@ -53,10 +52,6 @@ class FullAdditive(nn.Module):
     @property
     def output_layer(self):
         return self._output_layer
-
-    @property
-    def dropout_rate(self):
-        return self._dropout_rate
 
     @property
     def adj_matrix(self):

--- a/ranking_models/full_additive_joint_ranking.py
+++ b/ranking_models/full_additive_joint_ranking.py
@@ -23,8 +23,8 @@ class FullAdditiveJointRanker(nn.Module):
         """
         super(FullAdditiveJointRanker, self).__init__()
 
-        self._general_adj_matrix = nn.Linear(input_dim, input_dim)
-        self._general_noun_matrix = nn.Linear(input_dim, input_dim)
+        self._general_adj_matrix = nn.Parameter(torch.eye(input_dim), requires_grad=True)
+        self._general_noun_matrix = nn.Parameter(torch.eye(input_dim), requires_grad=True)
 
         self._adj_matrix_1 = nn.Parameter(torch.eye(input_dim), requires_grad=True)
         self._noun_matrix_1 = nn.Parameter(torch.eye(input_dim), requires_grad=True)
@@ -44,8 +44,14 @@ class FullAdditiveJointRanker(nn.Module):
         :return: the final composed phrase, representation 1, representation 2
         """
         device = batch["device"]
-        adj_vector = self._general_adj_matrix(batch["w1"].to(device))
-        noun_vector = self._general_noun_matrix(batch["w2"].to(device))
+
+        word_1 = batch["w1"].to(device)
+        word_2 = batch["w2"].to(device)
+
+        # general transformation
+        adj_vector = word_1.matmul(self._general_adj_matrix)
+        noun_vector = word_2.matmul(self._general_noun_matrix)
+
         if self.normalize_embeddings:
             adj_vector = F.normalize(adj_vector, p=2, dim=1)
             noun_vector = F.normalize(noun_vector, p=2, dim=1)

--- a/ranking_models/full_additive_joint_ranking.py
+++ b/ranking_models/full_additive_joint_ranking.py
@@ -1,0 +1,117 @@
+import torch.nn as nn
+import torch.nn.functional as F
+import utils.composition_functions as comp_functions
+import torch
+
+
+class FullAdditiveJointRanker(nn.Module):
+    """
+    This class contains the full additive composition model JOINT model. it trains two representations, each containing
+    a different type of semantic content (one for the general phrase and one to be close the the conveyed attribute).
+    Both representations are combined into one representation.
+    The model takes two words and returns their composed representation.
+    :param input_dim: embedding dimension
+    :param dropout_rate: dropout rate for regularization
+    :param normalize_embeddings: whether the composed representation should be normalized to unit length
+    """
+
+    def __init__(self, input_dim, dropout_rate, normalize_embeddings):
+        """
+        :param input_dim: embedding dimension
+        :param dropout_rate: dropout rate for regularization
+        :param normalize_embeddings: whether the composed representation should be normalized to unit length
+        """
+        super(FullAdditiveJointRanker, self).__init__()
+
+        self._general_adj_matrix = nn.Linear(input_dim, input_dim)
+        self._general_noun_matrix = nn.Linear(input_dim, input_dim)
+
+        self._adj_matrix_1 = nn.Parameter(torch.eye(input_dim), requires_grad=True)
+        self._noun_matrix_1 = nn.Parameter(torch.eye(input_dim), requires_grad=True)
+
+        self._adj_matrix_2 = nn.Parameter(torch.eye(input_dim), requires_grad=True)
+        self._noun_matrix_2 = nn.Parameter(torch.eye(input_dim), requires_grad=True)
+
+        self._dropout_rate = dropout_rate
+        self._normalize_embeddings = normalize_embeddings
+
+    def forward(self, batch):
+        """
+        this function takes two words, applies a general matrix transofrmation to first and second word and then
+        applies linear transformations with task specific adjective and noun matrices . The transformed vectors are combined
+        and these combined vectors are again combined to form the combined output vector
+        :param batch: a dictionary
+        :return: the final composed phrase, representation 1, representation 2
+        """
+        device = batch["device"]
+        adj_vector = self._general_adj_matrix(batch["w1"].to(device))
+        noun_vector = self._general_noun_matrix(batch["w2"].to(device))
+        if self.normalize_embeddings:
+            adj_vector = F.normalize(adj_vector, p=2, dim=1)
+            noun_vector = F.normalize(noun_vector, p=2, dim=1)
+
+        self._composed_phrase_1, self._composed_phrase_2 = self.compose(adj_vector, noun_vector)
+
+        self._final_composed_phrase = self._composed_phrase_1 + self._composed_phrase_2
+        if self.normalize_embeddings:
+            self._composed_phrase_1 = F.normalize(self._composed_phrase_1, p=2, dim=1)
+            self._composed_phrase_2 = F.normalize(self._composed_phrase_2, p=2, dim=1)
+            self._final_composed_phrase = F.normalize(self._final_composed_phrase, p=2, dim=1)
+        return self.final_composed_phrase, self.composed_phrase_1, self.composed_phrase_2
+
+    def compose(self, adj_vector, noun_vector):
+        """
+        this function takes two words, each will be transformed twice by a separate matrix.
+        :param word1: the first word of size batch_size x embedding size
+        :param word2: the first word of size batch_size x embedding size
+        :return: both composed phrases
+        """
+        composed_phrase_1 = comp_functions.full_additive(modifier_matrix=self._adj_matrix_1, modifier_vector=adj_vector,
+                                                         head_matrix=self._noun_matrix_1, head_vector=noun_vector)
+        composed_phrase_2 = comp_functions.full_additive(modifier_matrix=self.adj_matrix_2, modifier_vector=adj_vector,
+                                                         head_matrix=self._noun_matrix_2, head_vector=noun_vector)
+
+        return composed_phrase_1, composed_phrase_2
+
+    @property
+    def composed_phrase_1(self):
+        return self._composed_phrase_1
+
+    @property
+    def composed_phrase_2(self):
+        return self._composed_phrase_2
+
+    @property
+    def general_adj_matrix(self):
+        return self._general_adj_matrix
+
+    @property
+    def general_noun_matrix(self):
+        return self._general_noun_matrix
+
+    @property
+    def adj_matrix_1(self):
+        return self._adj_matrix_1
+
+    def noun_matrix_1(self):
+        return self._noun_matrix_1
+
+    @property
+    def adj_matrix_2(self):
+        return self._adj_matrix_2
+
+    @property
+    def noun_matrix_2(self):
+        return self._adj_matrix_2
+
+    @property
+    def final_composed_phrase(self):
+        return self._final_composed_phrase
+
+    @property
+    def dropout_rate(self):
+        return self._dropout_rate
+
+    @property
+    def normalize_embeddings(self):
+        return self._normalize_embeddings

--- a/ranking_models/matrix_joint_ranking.py
+++ b/ranking_models/matrix_joint_ranking.py
@@ -10,7 +10,7 @@ class MatrixJointRanker(nn.Module):
     The model is a basic matrix composition model with two specific linear transformation for each type of semantic representation.
     """
 
-    def __init__(self, input_dim, dropout_rate, normalize_embeddings):
+    def __init__(self, input_dim, dropout_rate, normalize_embeddings, non_linearity):
         """
         :param input_dim: embedding dimension
         :param dropout_rate: dropout rate for regularization
@@ -24,6 +24,7 @@ class MatrixJointRanker(nn.Module):
         self._specific_matrix_2 = nn.Linear(input_dim, input_dim)
         self._dropout_rate = dropout_rate
         self._normalize_embeddings = normalize_embeddings
+        self._non_linearity = non_linearity
 
     def forward(self, batch):
         """
@@ -35,6 +36,8 @@ class MatrixJointRanker(nn.Module):
         """
         device = batch["device"]
         self._composed_phrase = self.compose(batch["w1"].to(device), batch["w2"].to(device))
+        if self._non_linearity:
+            self._composed_phrase = F.relu(self._composed_phrase)
         self._representation_1 = self._specific_matrix_1(self._composed_phrase)
         self._representation_2 = self._specific_matrix_2(self._composed_phrase)
         if self.normalize_embeddings:
@@ -98,3 +101,6 @@ class MatrixJointRanker(nn.Module):
     def representation_2(self):
         return self._representation_2
 
+    @property
+    def non_linearity(self):
+        return self._non_linearity

--- a/ranking_models/matrix_joint_ranking.py
+++ b/ranking_models/matrix_joint_ranking.py
@@ -45,8 +45,6 @@ class MatrixJointRanker(nn.Module):
 
         if self.normalize_embeddings:
             self._final_composed_phrase = F.normalize(self._final_composed_phrase, p=2, dim=1)
-            self._representation_1 = F.normalize(self._representation_1, p=2, dim=1)
-            self._representation_2 = F.normalize(self._representation_2, p=2, dim=1)
 
         return self.final_composed_phrase, self.representation_1, self.representation_2
 

--- a/tests/test_full_additive.py
+++ b/tests/test_full_additive.py
@@ -7,7 +7,7 @@ from torch import optim
 from utils import loss_functions
 import torch.nn.functional as F
 from ranking_models import FullAdditive
-from utils.data_loader import PretrainCompmodelDataset
+from utils.data_loader import StaticRankingDataset
 from utils.composition_functions import full_additive
 
 
@@ -23,10 +23,10 @@ class FullAdditiveTest(unittest.TestCase):
         self._data_path_2 = pathlib.Path(__file__).parent.absolute().joinpath("data_pretraining/test.txt")
         self._embedding_path = str(pathlib.Path(__file__).parent.absolute().joinpath(
             "embeddings/german-skipgram-mincount-30-ctx-10-dims-300.fifu"))
-        self._dataset_1 = PretrainCompmodelDataset(self._data_path_1, self._embedding_path, head="head",
-                                                   mod="modifier", phrase="phrase", separator=" ")
-        self._dataset_2 = PretrainCompmodelDataset(self._data_path_2, self._embedding_path, head="head",
-                                                   mod="modifier", phrase="phrase", separator=" ")
+        self._dataset_1 = StaticRankingDataset(self._data_path_1, self._embedding_path, head="head",
+                                                   mod="modifier", phrase="label", separator=" ")
+        self._dataset_2 = StaticRankingDataset(self._data_path_2, self._embedding_path, head="head",
+                                                   mod="modifier", phrase="label", separator=" ")
         modifier_embeddings = F.normalize(torch.rand((50, 100)), dim=1)
         head_embeddings = F.normalize(torch.rand((50, 100)), dim=1)
         gold_composed = F.normalize(torch.rand((50, 100)), dim=1)

--- a/tests/test_joint_full_additive.py
+++ b/tests/test_joint_full_additive.py
@@ -1,0 +1,123 @@
+import unittest
+import math
+import pathlib
+import numpy as np
+import torch
+from torch import optim
+from utils import loss_functions
+import torch.nn.functional as F
+from ranking_models import FullAdditiveJointRanker
+from utils.data_loader import StaticRankingDataset, MultiRankingDataset
+from torch.utils.data import DataLoader
+
+
+class JointFullAdditiveRanking(unittest.TestCase):
+    """
+    this class tests the joint matrix model
+    This test suite can be ran with:
+        python -m unittest -q tests.JointRankingTest
+    """
+
+    def setUp(self):
+        self._data_path_1 = pathlib.Path(__file__).parent.absolute().joinpath("/Users/ehuber/Documents/ambiguous_alpaca/ambigous-alpaca/Data/test_data_for_ranking_tests/test.txt")
+        self._data_path_2 = pathlib.Path(__file__).parent.absolute().joinpath("/Users/ehuber/Documents/ambiguous_alpaca/ambigous-alpaca/Data/test_data_for_ranking_tests/val.txt")
+        self._embedding_path = str(pathlib.Path(__file__).parent.absolute().joinpath(
+            "embeddings/german-skipgram-mincount-30-ctx-10-dims-300.fifu"))
+        self._dataset_1 = StaticRankingDataset(self._data_path_1, self._embedding_path, head="head",
+                                               mod="modifier", phrase="label", separator=" ")
+        self._dataset_2 = StaticRankingDataset(self._data_path_2, self._embedding_path, head="head",
+                                               mod="modifier", phrase="label", separator=" ")
+        modifier_embeddings = F.normalize(torch.rand((50, 100)), dim=1)
+        head_embeddings = F.normalize(torch.rand((50, 100)), dim=1)
+        gold_composed = F.normalize(torch.rand((50, 100)), dim=1)
+        device = torch.device("cpu")
+        self.input_1 = {"w1": modifier_embeddings, "w2": head_embeddings, "l": gold_composed, "device": device}
+        self.input_2 = {"w1": modifier_embeddings, "w2": head_embeddings, "l": gold_composed, "device": device}
+        self.model = FullAdditiveJointRanker(input_dim=100, dropout_rate=0.0, normalize_embeddings=True)
+        self.optimizer = optim.Adam(self.model.parameters(), lr=0.1)
+
+    @staticmethod
+    def access_named_parameter(model, parameter_name):
+        for name, param in model.named_parameters():
+            if param.requires_grad:
+                if name == parameter_name:
+                    return param.clone()
+
+
+    def test_model_loss(self):
+        self.optimizer.zero_grad()
+        composed, rep_1, rep_2 = self.model(self.input_1)
+        loss_1 = loss_functions.get_loss_cosine_distance(original_phrase=self.input_1["l"], composed_phrase=rep_1,
+                                                         dim=1, normalize=False).item()
+        composed, rep_1, rep_2 = self.model(self.input_2)
+        loss_2 = loss_functions.get_loss_cosine_distance(original_phrase=self.input_1["l"], composed_phrase=rep_2,
+                                                         dim=1, normalize=False).item()
+        np.testing.assert_equal(math.isnan(loss_1), False)
+        np.testing.assert_equal(math.isnan(loss_2), False)
+
+        np.testing.assert_equal(loss_1 >= 0, True)
+        np.testing.assert_equal(loss_2 >= 0, True)
+
+
+
+
+    def test_parameter_updated_with_training(self):
+        adj_1_before_training = self.access_named_parameter(self.model, "_adj_matrix_1")
+        adj_2_before_training = self.access_named_parameter(self.model, "_adj_matrix_2")
+        noun_1_before_training = self.access_named_parameter(self.model, "_noun_matrix_1")
+        noun_2_before_training = self.access_named_parameter(self.model, "_noun_matrix_2")
+
+        general_adj_weights_before_training = self.access_named_parameter(self.model, "_general_adj_matrix.weight")
+        general_noun_weights_before_training = self.access_named_parameter(self.model, "_general_noun_matrix.weight")
+
+        for epoch in range(0,5):
+            self.optimizer.zero_grad()
+            composed, rep_1, rep_2 = self.model(self.input_1)
+            loss_1 = loss_functions.get_loss_cosine_distance(original_phrase=self.input_1["l"], composed_phrase=rep_1,
+                                                             dim=1, normalize=False)
+            composed, rep_1, rep_2 = self.model(self.input_2)
+            loss_2 = loss_functions.get_loss_cosine_distance(original_phrase=self.input_1["l"], composed_phrase=rep_2,
+                                                             dim=1, normalize=False)
+            loss = loss_1 + loss_2
+            loss.backward()
+            self.optimizer.step()
+            adj_1_after_training = self.access_named_parameter(self.model, "_adj_matrix_1")
+            adj_2_after_training = self.access_named_parameter(self.model, "_adj_matrix_2")
+            noun_1_after_training = self.access_named_parameter(self.model, "_noun_matrix_1")
+            noun_2_after_training = self.access_named_parameter(self.model, "_noun_matrix_2")
+            general_adj_weights_after_training = self.access_named_parameter(self.model, "_general_adj_matrix.weight")
+            general_noun_weights_after_training = self.access_named_parameter(self.model,
+                                                                               "_general_noun_matrix.weight")
+            
+        difference_adj1_layer = torch.sum(
+            adj_1_before_training - adj_1_after_training ).item()
+        difference_adj2_layer = torch.sum(
+            adj_2_before_training - adj_2_after_training).item()
+        difference_noun1_layer = torch.sum(
+            noun_1_before_training- noun_1_after_training).item()
+        difference_noun2_layer = torch.sum(noun_2_before_training - noun_2_after_training).item()
+
+        difference_general_adj = torch.sum(general_adj_weights_before_training - general_adj_weights_after_training).item()
+        difference_general_noun = torch.sum(general_noun_weights_before_training - general_noun_weights_after_training).item()
+
+        np.testing.assert_equal(difference_adj1_layer != 0.0, True)
+        np.testing.assert_equal(difference_adj2_layer != 0.0, True)
+        np.testing.assert_equal(difference_noun1_layer != 0.0, True)
+        np.testing.assert_equal(difference_noun2_layer != 0.0, True)
+        np.testing.assert_equal(difference_general_adj != 0.0, True)
+        np.testing.assert_equal(difference_general_noun != 0.0, True)
+
+
+    def test_output_shape(self):
+        expected_shape = np.array([50, 100])
+        composed_phrase, rep_1, rep_2 = self.model(self.input_2)
+        np.testing.assert_almost_equal(composed_phrase.shape, expected_shape)
+        np.testing.assert_almost_equal(rep_1.shape, expected_shape)
+        np.testing.assert_almost_equal(rep_2.shape, expected_shape)
+
+    def test_embedding_normalization(self):
+        """Test whether the composed phrase has been normalized to unit norm"""
+        composed_phrase, rep_1, rep_2 = self.model(self.input_2)
+        np.testing.assert_almost_equal(np.linalg.norm(composed_phrase[0].data), 1.0)
+        np.testing.assert_almost_equal(np.linalg.norm(rep_1[0].data), 1.0)
+        np.testing.assert_almost_equal(np.linalg.norm(rep_2[0].data), 1.0)

--- a/tests/test_joint_full_additive.py
+++ b/tests/test_joint_full_additive.py
@@ -31,6 +31,7 @@ class JointFullAdditiveRanking(unittest.TestCase):
         head_embeddings = F.normalize(torch.rand((50, 100)), dim=1)
         gold_composed = F.normalize(torch.rand((50, 100)), dim=1)
         device = torch.device("cpu")
+
         self.input_1 = {"w1": modifier_embeddings, "w2": head_embeddings, "l": gold_composed, "device": device}
         self.input_2 = {"w1": modifier_embeddings, "w2": head_embeddings, "l": gold_composed, "device": device}
         self.model = FullAdditiveJointRanker(input_dim=100, dropout_rate=0.0, normalize_embeddings=True)
@@ -67,8 +68,8 @@ class JointFullAdditiveRanking(unittest.TestCase):
         noun_1_before_training = self.access_named_parameter(self.model, "_noun_matrix_1")
         noun_2_before_training = self.access_named_parameter(self.model, "_noun_matrix_2")
 
-        general_adj_weights_before_training = self.access_named_parameter(self.model, "_general_adj_matrix.weight")
-        general_noun_weights_before_training = self.access_named_parameter(self.model, "_general_noun_matrix.weight")
+        general_adj_weights_before_training = self.access_named_parameter(self.model, "_general_adj_matrix")
+        general_noun_weights_before_training = self.access_named_parameter(self.model, "_general_noun_matrix")
 
         for epoch in range(0,5):
             self.optimizer.zero_grad()
@@ -85,9 +86,9 @@ class JointFullAdditiveRanking(unittest.TestCase):
             adj_2_after_training = self.access_named_parameter(self.model, "_adj_matrix_2")
             noun_1_after_training = self.access_named_parameter(self.model, "_noun_matrix_1")
             noun_2_after_training = self.access_named_parameter(self.model, "_noun_matrix_2")
-            general_adj_weights_after_training = self.access_named_parameter(self.model, "_general_adj_matrix.weight")
+            general_adj_weights_after_training = self.access_named_parameter(self.model, "_general_adj_matrix")
             general_noun_weights_after_training = self.access_named_parameter(self.model,
-                                                                               "_general_noun_matrix.weight")
+                                                                               "_general_noun_matrix")
             
         difference_adj1_layer = torch.sum(
             adj_1_before_training - adj_1_after_training ).item()

--- a/tests/test_joint_full_additive.py
+++ b/tests/test_joint_full_additive.py
@@ -19,8 +19,8 @@ class JointFullAdditiveRanking(unittest.TestCase):
     """
 
     def setUp(self):
-        self._data_path_1 = pathlib.Path(__file__).parent.absolute().joinpath("/Users/ehuber/Documents/ambiguous_alpaca/ambigous-alpaca/Data/test_data_for_ranking_tests/test.txt")
-        self._data_path_2 = pathlib.Path(__file__).parent.absolute().joinpath("/Users/ehuber/Documents/ambiguous_alpaca/ambigous-alpaca/Data/test_data_for_ranking_tests/val.txt")
+        self._data_path_1 = pathlib.Path(__file__).parent.absolute().joinpath("data_pretraining/train.txt")
+        self._data_path_2 = pathlib.Path(__file__).parent.absolute().joinpath("data_pretraining/test.txt")
         self._embedding_path = str(pathlib.Path(__file__).parent.absolute().joinpath(
             "embeddings/german-skipgram-mincount-30-ctx-10-dims-300.fifu"))
         self._dataset_1 = StaticRankingDataset(self._data_path_1, self._embedding_path, head="head",

--- a/tests/test_joint_matrix_ranking.py
+++ b/tests/test_joint_matrix_ranking.py
@@ -24,17 +24,16 @@ class JointMatrixRanking(unittest.TestCase):
         self._embedding_path = str(pathlib.Path(__file__).parent.absolute().joinpath(
             "embeddings/german-skipgram-mincount-30-ctx-10-dims-300.fifu"))
         self._dataset_1 = StaticRankingDataset(self._data_path_1, self._embedding_path, head="head",
-                                               mod="modifier", phrase="phrase", separator=" ")
+                                               mod="modifier", phrase="label", separator=" ")
         self._dataset_2 = StaticRankingDataset(self._data_path_2, self._embedding_path, head="head",
-                                               mod="modifier", phrase="phrase", separator=" ")
+                                               mod="modifier", phrase="label", separator=" ")
         modifier_embeddings = F.normalize(torch.rand((50, 100)), dim=1)
         head_embeddings = F.normalize(torch.rand((50, 100)), dim=1)
         gold_composed = F.normalize(torch.rand((50, 100)), dim=1)
         device = torch.device("cpu")
         self.input_1 = {"w1": modifier_embeddings, "w2": head_embeddings, "l": gold_composed, "device": device}
         self.input_2 = {"w1": modifier_embeddings, "w2": head_embeddings, "l": gold_composed, "device": device}
-        self.model = MatrixJointRanker(input_dim=100, dropout_rate=0.0, normalize_embeddings=True,
-                                       rep1_weight=0.3, rep2_weight=0.7)
+        self.model = MatrixJointRanker(input_dim=100, dropout_rate=0.0, normalize_embeddings=True)
         self.optimizer = optim.Adam(self.model.parameters(), lr=0.1)
 
     @staticmethod

--- a/training_scripts/joint_training.py
+++ b/training_scripts/joint_training.py
@@ -166,7 +166,8 @@ def predict(test_loader, model, device):
         test_loss_att.append(loss_att.item())
         test_loss_reconstructed.append(loss_reconstructed.item())
         test_loss_final.append(loss_final.item())
-        orig_phrases.append(batch["phrase"])
+        test_loss_final.append(loss_final.item())
+        orig_phrases.append(batch["label"])
     orig_phrases = [item for sublist in orig_phrases for item in sublist]
     predictions_final_rep = np.array(predictions_final_rep)
     predictions_attribute_rep = np.array(predictions_attribute_rep)
@@ -214,19 +215,19 @@ def evaluate(predictions_final_phrase, predictions_att_rep, predictions_reconstr
                                              embedding_extractor=embedding_extractor,
                                              data_loader=rank_loader,
                                              all_labels=labels,
-                                             y_label="phrase", max_rank=1000)
+                                             y_label="label", max_rank=1000)
     ranker_attribute.save_ranks(ranks_att_rep)
     ranker_reconstructed = NearestNeigbourRanker(path_to_predictions=predictions_reconstructed_rep,
                                                  embedding_extractor=embedding_extractor,
                                                  data_loader=rank_loader,
                                                  all_labels=labels,
-                                                 y_label="phrase", max_rank=1000)
+                                                 y_label="label", max_rank=1000)
     ranker_reconstructed.save_ranks(ranks_reconstructed_rep)
     ranker_final_rep = NearestNeigbourRanker(path_to_predictions=predictions_final_phrase,
                                              embedding_extractor=embedding_extractor,
                                              data_loader=rank_loader,
                                              all_labels=labels,
-                                             y_label="phrase", max_rank=1000)
+                                             y_label="label", max_rank=1000)
     ranker_final_rep.save_ranks(ranks_final_phrase)
 
     logger.info(("result for learned attribute representation"))

--- a/training_scripts/joint_training.py
+++ b/training_scripts/joint_training.py
@@ -398,7 +398,7 @@ if __name__ == "__main__":
         logger.info("test loss final phrase: %.5f" % test_loss_final)
         evaluate(predictions_final_phrase=prediction_path_test_final_rep,
                  predictions_att_rep=prediction_path_test_attribute_rep,
-                 predictions_reconstructed_rep=test_predictions_rec, ranks_final_phrase=rank_path_test_final_rep,
+                 predictions_reconstructed_rep=prediction_path_test_reconstructed, ranks_final_phrase=rank_path_test_final_rep,
                  ranks_att_rep=rank_path_test_attribute_rep, ranks_reconstructed_rep=rank_path_test_reconstructed,
                  dataset=dataset_test_2, labels=labels_dataset_2,
                  embedding_extractor=feature_extractor)

--- a/utils/training_utils.py
+++ b/utils/training_utils.py
@@ -2,7 +2,7 @@ import torch
 from classification_models import BasicTwoWordClassifier, TransweighTwoWordClassifier, TransferCompClassifier, \
     PhraseContextClassifier, MatrixTwoWordClassifier, MatrixTransferClassifier
 from ranking_models import TransweighPretrain, MatrixPretrain, MatrixTransferRanker, TransweighTransferRanker, \
-    TransweighJointRanker, MatrixJointRanker, FullAdditive
+    TransweighJointRanker, MatrixJointRanker, FullAdditive, FullAdditiveJointRanker
 
 from utils import SimplePhraseContextualizedDataset, SimplePhraseStaticDataset, \
     PhraseAndContextDatasetStatic, PhraseAndContextDatasetBert, StaticRankingDataset, ContextualizedRankingDataset
@@ -92,7 +92,7 @@ def init_classifier(config):
                                        dropout_rate=config["model"]["dropout"],
                                        normalize_embeddings=config["model"]["normalize_embeddings"])
     if config["model"]["type"] == "joint_ranking_full_additive":
-        classifier = MatrixJointRanker(input_dim=config["model"]["input_dim"],
+        classifier = FullAdditiveJointRanker(input_dim=config["model"]["input_dim"],
                                        dropout_rate=config["model"]["dropout"],
                                        normalize_embeddings=config["model"]["normalize_embeddings"])
 

--- a/utils/training_utils.py
+++ b/utils/training_utils.py
@@ -83,15 +83,15 @@ def init_classifier(config):
                                   dropout_rate=config["model"]["dropout"],
                                   normalize_embeddings=config["model"]["normalize_embeddings"])
     if config["model"]["type"] == "joint_ranking":
-        assert config["model"]["task_weights"][0] + config["model"]["task_weights"][
-            1] == 1.0, "the task weights have to sum to 1"
         classifier = TransweighJointRanker(input_dim=config["model"]["input_dim"],
                                            dropout_rate=config["model"]["dropout"],
                                            normalize_embeddings=config["model"]["normalize_embeddings"],
                                            transformations=config["model"]["transformations"])
     if config["model"]["type"] == "joint_ranking_matrix":
-        assert config["model"]["task_weights"][0] + config["model"]["task_weights"][
-            1] == 1.0, "the task weights have to sum to 1"
+        classifier = MatrixJointRanker(input_dim=config["model"]["input_dim"],
+                                       dropout_rate=config["model"]["dropout"],
+                                       normalize_embeddings=config["model"]["normalize_embeddings"])
+    if config["model"]["type"] == "joint_ranking_full_additive":
         classifier = MatrixJointRanker(input_dim=config["model"]["input_dim"],
                                        dropout_rate=config["model"]["dropout"],
                                        normalize_embeddings=config["model"]["normalize_embeddings"])

--- a/utils/training_utils.py
+++ b/utils/training_utils.py
@@ -90,11 +90,13 @@ def init_classifier(config):
     if config["model"]["type"] == "joint_ranking_matrix":
         classifier = MatrixJointRanker(input_dim=config["model"]["input_dim"],
                                        dropout_rate=config["model"]["dropout"],
-                                       normalize_embeddings=config["model"]["normalize_embeddings"])
+                                       normalize_embeddings=config["model"]["normalize_embeddings"],
+                                       non_linearity=config["model"]["non_linearity"])
     if config["model"]["type"] == "joint_ranking_full_additive":
         classifier = FullAdditiveJointRanker(input_dim=config["model"]["input_dim"],
-                                       dropout_rate=config["model"]["dropout"],
-                                       normalize_embeddings=config["model"]["normalize_embeddings"])
+                                             dropout_rate=config["model"]["dropout"],
+                                             normalize_embeddings=config["model"]["normalize_embeddings"],
+                                             non_linearity=config["model"]["non_linearity"])
 
     assert classifier, "no valid classifier name specified in the configuration"
     return classifier
@@ -148,7 +150,7 @@ def get_datasets(config):
                                                             max_len=max_len, separator=separator,
                                                             batch_size=batch_size,
                                                             label=label, mod=mod, head=head,
-                                                             label_definition_path=definition_file)
+                                                            label_definition_path=definition_file)
             else:
                 # phrase only
                 dataset_train = SimplePhraseContextualizedDataset(data_path=config["train_data_path"],

--- a/utils/training_utils.py
+++ b/utils/training_utils.py
@@ -80,7 +80,6 @@ def init_classifier(config):
                                     normalize_embeddings=config["model"]["normalize_embeddings"])
     if config["model"]["type"] == "full_additive_pretrain":
         classifier = FullAdditive(input_dim=config["model"]["input_dim"],
-                                  dropout_rate=config["model"]["dropout"],
                                   normalize_embeddings=config["model"]["normalize_embeddings"])
     if config["model"]["type"] == "joint_ranking":
         classifier = TransweighJointRanker(input_dim=config["model"]["input_dim"],
@@ -94,7 +93,6 @@ def init_classifier(config):
                                        non_linearity=config["model"]["non_linearity"])
     if config["model"]["type"] == "joint_ranking_full_additive":
         classifier = FullAdditiveJointRanker(input_dim=config["model"]["input_dim"],
-                                             dropout_rate=config["model"]["dropout"],
                                              normalize_embeddings=config["model"]["normalize_embeddings"],
                                              non_linearity=config["model"]["non_linearity"])
 


### PR DESCRIPTION
This PR contains the full additive model as a joint model and a test unit to test it. 
First, the adjective and the noun get transformed by individual weights. Then, the adjective and noun are linearly transformed separately: 1) for attribute prediction 2) for phrase reconstruction. 
These two vectors are summed to form the combined vector. 
Thus, the model has three output vectors.

I also removed redundant embedding normalization in the matrix_joint_model (the tests still works). 

